### PR TITLE
Add visibility-aware repo profiles

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Install validation dependencies
+        run: python -m pip install PyYAML
       - name: Fetch skill-creator helper
         run: |
           git clone --depth=1 https://github.com/openai/skills.git /tmp/openai-skills

--- a/.project/logs/visibility-profiles.md
+++ b/.project/logs/visibility-profiles.md
@@ -6,3 +6,4 @@
 - Recorded that GitHub connector issue creation failed with `403`; issue creation will use `gh issue create --body-file`.
 - Created issue https://github.com/emmepra/ora-et-labora/issues/1 and moved work to branch `feat/1-visibility-profiles`.
 - Implemented profile-aware skill guidance, `.gitignore` bootstrap behavior, and unit coverage; `python scripts/validate_all.py` passed.
+- Opened PR https://github.com/emmepra/ora-et-labora/pull/2 targeting `dev`; PR body includes `Closes #1`.

--- a/.project/logs/visibility-profiles.md
+++ b/.project/logs/visibility-profiles.md
@@ -8,3 +8,4 @@
 - Implemented profile-aware skill guidance, `.gitignore` bootstrap behavior, and unit coverage; `python scripts/validate_all.py` passed.
 - Opened PR https://github.com/emmepra/ora-et-labora/pull/2 targeting `dev`; PR body includes `Closes #1`.
 - Investigated failing GitHub `validate` check: runner lacked PyYAML for `quick_validate.py`. Added workflow dependency install and reran local validation successfully.
+- Confirmed GitHub PR check `validate` passed after the CI fix.

--- a/.project/logs/visibility-profiles.md
+++ b/.project/logs/visibility-profiles.md
@@ -1,0 +1,8 @@
+# Visibility-Aware Repo Modes Log
+
+## 2026-04-19
+
+- Started a repo-local Ora task record for public/private/internal artifact policy.
+- Recorded that GitHub connector issue creation failed with `403`; issue creation will use `gh issue create --body-file`.
+- Created issue https://github.com/emmepra/ora-et-labora/issues/1 and moved work to branch `feat/1-visibility-profiles`.
+- Implemented profile-aware skill guidance, `.gitignore` bootstrap behavior, and unit coverage; `python scripts/validate_all.py` passed.

--- a/.project/logs/visibility-profiles.md
+++ b/.project/logs/visibility-profiles.md
@@ -7,3 +7,4 @@
 - Created issue https://github.com/emmepra/ora-et-labora/issues/1 and moved work to branch `feat/1-visibility-profiles`.
 - Implemented profile-aware skill guidance, `.gitignore` bootstrap behavior, and unit coverage; `python scripts/validate_all.py` passed.
 - Opened PR https://github.com/emmepra/ora-et-labora/pull/2 targeting `dev`; PR body includes `Closes #1`.
+- Investigated failing GitHub `validate` check: runner lacked PyYAML for `quick_validate.py`. Added workflow dependency install and reran local validation successfully.

--- a/.project/todo/visibility-profiles/00_brainstorm.md
+++ b/.project/todo/visibility-profiles/00_brainstorm.md
@@ -1,0 +1,38 @@
+# Visibility-Aware Repo Modes
+
+## Problem
+
+Ora et Labora needs explicit public/private/internal repository modes so agents do not publish private workflow state in public repos or lose useful `.project` memory in private/internal repos.
+
+## Challenge Collection
+
+- Public repositories should not commit private agent state, raw browser artifacts, local paths, private hostnames, screenshots with sensitive content, or issue-planning notes.
+- Private and internal repositories still benefit from versioned `.project/blueprint/`, `.project/todo/`, and concise `.project/logs/` because those files are the workflow memory layer.
+- The rule must be executable, not just advisory, because agents otherwise forget it during repo init/bootstrap.
+- Playwright artifact handling must stay disciplined across all modes: summaries and evidence paths are useful; raw traces, videos, HAR files, and screenshots are risky or noisy by default.
+
+## Options
+
+- Documentation only: too weak; agents can still forget the artifact policy.
+- Script-only: too opaque; agents need to understand why each profile behaves differently.
+- Skill docs plus bootstrap script: preferred because it gives both future-agent context and deterministic repo output.
+
+## Decision
+
+Implement profile-aware repo setup across the skill docs and bootstrap helper:
+
+- `private`: version workflow memory, ignore worktrees and raw browser payloads.
+- `internal`: same as private, with broader-reader caution.
+- `public`: keep `.project/` and local agent state ignored by default; publish only sanitized public docs and GitHub templates.
+
+## Blueprint Fit
+
+- Fits Ora et Labora's repo-first memory model because the policy is stored in the repo and applied by a helper script.
+- Updates durable workflow knowledge because visibility now affects artifact ownership and bootstrap behavior.
+- Does not change branch or release policy.
+
+## Verification Plan
+
+- Add unit tests for default/private bootstrap behavior.
+- Add unit tests for public bootstrap behavior.
+- Run `python scripts/validate_all.py`.

--- a/.project/todo/visibility-profiles/CURRENT.md
+++ b/.project/todo/visibility-profiles/CURRENT.md
@@ -1,0 +1,28 @@
+# Current State - Visibility-Aware Repo Modes
+
+## Status
+
+Implementation complete; PR pending.
+
+## Issue
+
+https://github.com/emmepra/ora-et-labora/issues/1
+
+## Branch
+
+`feat/1-visibility-profiles`
+
+## Latest Work
+
+- Added visibility profile policy to `repo-init`, `repo-bootstrap`, and the suite index.
+- Updated `bootstrap_repo_templates.py` to write profile-aware `.gitignore` rules.
+- Added tests for private/default and public profile behavior.
+- Verified with `python scripts/validate_all.py`.
+
+## Next Step
+
+- Commit, push, and open a PR to `dev`.
+
+## Blockers
+
+- None.

--- a/.project/todo/visibility-profiles/CURRENT.md
+++ b/.project/todo/visibility-profiles/CURRENT.md
@@ -21,11 +21,12 @@ https://github.com/emmepra/ora-et-labora/pull/2
 - Added visibility profile policy to `repo-init`, `repo-bootstrap`, and the suite index.
 - Updated `bootstrap_repo_templates.py` to write profile-aware `.gitignore` rules.
 - Added tests for private/default and public profile behavior.
+- Fixed CI validation dependency setup for `quick_validate.py`.
 - Verified with `python scripts/validate_all.py`.
 
 ## Next Step
 
-- Await PR review/merge into `dev`.
+- Await CI rerun and PR review/merge into `dev`.
 
 ## Blockers
 

--- a/.project/todo/visibility-profiles/CURRENT.md
+++ b/.project/todo/visibility-profiles/CURRENT.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implementation complete; PR pending.
+Implementation complete; PR open.
 
 ## Issue
 
@@ -11,6 +11,10 @@ https://github.com/emmepra/ora-et-labora/issues/1
 ## Branch
 
 `feat/1-visibility-profiles`
+
+## PR
+
+https://github.com/emmepra/ora-et-labora/pull/2
 
 ## Latest Work
 
@@ -21,7 +25,7 @@ https://github.com/emmepra/ora-et-labora/issues/1
 
 ## Next Step
 
-- Commit, push, and open a PR to `dev`.
+- Await PR review/merge into `dev`.
 
 ## Blockers
 

--- a/.project/todo/visibility-profiles/CURRENT.md
+++ b/.project/todo/visibility-profiles/CURRENT.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implementation complete; PR open.
+Implementation complete; PR open and checks passing.
 
 ## Issue
 
@@ -23,10 +23,11 @@ https://github.com/emmepra/ora-et-labora/pull/2
 - Added tests for private/default and public profile behavior.
 - Fixed CI validation dependency setup for `quick_validate.py`.
 - Verified with `python scripts/validate_all.py`.
+- GitHub PR check `validate` passed.
 
 ## Next Step
 
-- Await CI rerun and PR review/merge into `dev`.
+- Await PR review/merge into `dev`.
 
 ## Blockers
 

--- a/.project/todo/visibility-profiles/issue.md
+++ b/.project/todo/visibility-profiles/issue.md
@@ -1,0 +1,26 @@
+## Problem
+
+Ora et Labora needs explicit public/private/internal repository modes so agents do not publish private workflow state in public repos or lose useful `.project` memory in private/internal repos.
+
+## Scope
+
+- Define visibility profiles for `repo-init`, `repo-bootstrap`, and the suite index.
+- Make bootstrap apply a profile-aware `.gitignore` artifact policy.
+- Cover public/private behavior with tests.
+- Keep raw Playwright artifacts disciplined by default.
+
+## Acceptance Criteria
+
+- Public mode keeps `.project/` and local agent state ignored by default.
+- Private/internal modes keep `.project` workflow memory versionable while ignoring worktrees and raw browser artifacts.
+- Bootstrap script accepts a visibility/profile option.
+- Tests cover default/private and public behavior.
+- README explains the workflow impact.
+
+## Verification
+
+- Run `python scripts/validate_all.py`.
+
+## Notes
+
+This issue is user-directed from the Ora et Labora workflow refinement discussion.

--- a/.project/todo/visibility-profiles/pr.md
+++ b/.project/todo/visibility-profiles/pr.md
@@ -1,0 +1,17 @@
+## Summary
+
+- Adds public/private/internal visibility profiles to the Ora et Labora repo setup workflow.
+- Updates `repo-init`, `repo-bootstrap`, and the suite index so artifact publication policy is explicit before setup.
+- Extends `bootstrap_repo_templates.py` with `--visibility <private|internal|public>` and profile-aware `.gitignore` policy.
+- Adds tests for private/default, public, and profile replacement behavior.
+
+Closes #1
+
+## Verification
+
+- `python scripts/validate_all.py`
+
+## Risk / Notes
+
+- Public profile now ignores `.project/` by default, so public repos still get local Ora state but do not publish it unless deliberately sanitized.
+- Private/internal profiles keep workflow memory versionable while ignoring worktrees and raw Playwright payloads.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The suite is built around a simple idea:
 - verify using the right modality for the change
 - make implementation PRs close their originating issues on merge
 - treat browser evidence and Docker runtime behavior as first-class operational concerns
+- choose a public/private/internal artifact policy before publishing workflow state
 - integrate into `dev`
 - release from `dev` to `main`
 
@@ -26,6 +27,8 @@ Once the issue is shaped, the skill creates or resumes a branch-local execution 
 Implementation then happens inside the worktree, with verification driven by the type of change. Frontend work is not "tested" in the abstract; it is verified in the browser, with Playwright evidence collected into a stable repo-local log path. Docker-backed projects are handled with explicit worktree rules so switching branches does not turn into port collisions and stale containers.
 
 The branch flow is PR-first into `dev`, while stable promotion happens through grouped `dev` to `main` release PRs.
+
+Repo creation and bootstrap are visibility-aware. Private and internal repos can version `.project/` as durable agent memory, while public repos keep `.project/` local by default and publish only sanitized contributor-facing docs and GitHub templates.
 
 ## The Basic Workflow
 
@@ -65,6 +68,7 @@ The branch flow is PR-first into `dev`, while stable promotion happens through g
 - Browser verification requires evidence, not just a claim.
 - Implementation PRs must reference and close their originating issues.
 - Docker behavior across worktrees must be explicit.
+- Public repos keep agent-private state local unless explicitly sanitized.
 - `dev` is the integration branch.
 - `main` is the stable branch.
 
@@ -93,7 +97,7 @@ The suite includes:
 - detailed self-contained `SKILL.md` bodies with procedure, red flags, rationalization counters, and completion checklists
 - issue, PR, release, brainstorm, current-state, and log templates
 - bootstrap assets for `.github/` and `.project/blueprint/`
-- helper scripts for template rendering, issue workspace initialization, and Playwright artifact collection
+- helper scripts for template rendering, issue workspace initialization, visibility-aware bootstrap, and Playwright artifact collection
 
 The operating procedure is intentionally inline in the skill files. Extra files are reserved for templates, scripts, bootstrap assets, tests, and examples.
 

--- a/skills/ora-et-labora/SKILL.md
+++ b/skills/ora-et-labora/SKILL.md
@@ -77,6 +77,8 @@ Do not use this skill as a substitute for the detailed phase skills. If the task
 
 - Read the closest `AGENTS.md` before acting.
 - Treat `.project/` as the canonical operational surface unless the target repo explicitly chose a different convention before this skill was invoked.
+- Choose the repository visibility profile before creating or bootstrapping workflow artifacts.
+- For public repos, keep `.project/` local by default and publish only sanitized contributor-facing docs.
 - Run a blueprint fit check for every nontrivial issue before implementation starts.
 - Update `.project/blueprint/` only when durable project knowledge changes.
 - Keep logs delta-only. Do not restate information that already lives in GitHub or `CURRENT.md`.
@@ -100,6 +102,26 @@ Do not use this skill as a substitute for the detailed phase skills. If the task
 | `.project/blueprint/` | durable project model and workflow invariants | task-local notes, transient blockers |
 | PR body | implementation summary, closing issue reference, verification evidence, risks, rollback/follow-ups | unresolved template placeholders, raw traces |
 | release PR | grouped scope, release checks, migrations, rollback | individual implementation diaries |
+
+## Visibility Profiles
+
+Ora et Labora supports three repository modes:
+
+| Profile | Use for | Default artifact policy |
+| --- | --- | --- |
+| `private` | personal/private projects | version `.project/blueprint`, `.project/todo`, and concise `.project/logs`; ignore worktrees and raw browser artifacts |
+| `internal` | organization-visible private projects | same as private, but avoid personal notes and write for broader internal readers |
+| `public` | open source or public portfolio work | version `.github` and sanitized public docs; keep `.project`, local issue workspaces, raw browser artifacts, and private agent instructions local by default |
+
+Visibility affects workflow design. Do not treat it as only a GitHub setting.
+
+When using `repo-init` or `repo-bootstrap`, apply the profile with:
+
+```bash
+python skills/ora-et-labora/scripts/bootstrap_repo_templates.py --repo-root <repo> --visibility <private|internal|public>
+```
+
+Public repos can still use Ora et Labora locally. The difference is that local operational memory stays outside the published source unless the user explicitly approves a sanitized subset.
 
 ## Nontrivial Work Definition
 
@@ -191,6 +213,7 @@ Scripts live under `scripts/`:
 - `render_template.py`: render markdown templates with strict placeholder replacement.
 - `init_issue_workspace.py`: initialize `00_brainstorm.md`, `CURRENT.md`, and task log.
 - `bootstrap_repo_templates.py`: copy GitHub templates, blueprint docs, and workflow examples into a target repo.
+- `bootstrap_repo_templates.py --visibility <profile>`: also writes the profile-aware artifact policy into `.gitignore`.
 - `collect_playwright_artifacts.py`: collect browser verification artifacts into `.project/logs/playwright/<module-id>/<run-id>/`.
 
 Prefer scripts for deterministic file layout and template rendering.
@@ -202,6 +225,7 @@ Prefer scripts for deterministic file layout and template rendering.
 - "I will use one log file for every branch."
 - "I will open a PR to `main` for normal feature work."
 - "I will open the PR without `Closes #<issue>` and close the issue manually later."
+- "I will publish `.project/` in a public repo because it is only process state."
 - "I will claim frontend verification without browser evidence."
 - "I will paste complex markdown directly into `gh issue create`."
 - "I will use parallel Docker stacks without isolated ports and project names."

--- a/skills/ora-et-labora/scripts/bootstrap_repo_templates.py
+++ b/skills/ora-et-labora/scripts/bootstrap_repo_templates.py
@@ -8,9 +8,58 @@ import shutil
 from pathlib import Path
 
 
+BEGIN_MARKER = "# BEGIN Ora et Labora artifact policy"
+END_MARKER = "# END Ora et Labora artifact policy"
+
+GITIGNORE_PROFILES = {
+    "private": [
+        "# Local worktree checkouts are never repository content.",
+        ".project/worktrees/",
+        "",
+        "# Keep browser verification summaries, but do not commit raw Playwright payloads by default.",
+        ".project/logs/playwright/**/*.zip",
+        ".project/logs/playwright/**/*.webm",
+        ".project/logs/playwright/**/*.mp4",
+        ".project/logs/playwright/**/*.har",
+        ".project/logs/playwright/**/*.png",
+        ".project/logs/playwright/**/*.jpg",
+        ".project/logs/playwright/**/*.jpeg",
+        "playwright-report/",
+        "test-results/",
+    ],
+    "internal": [
+        "# Local worktree checkouts are never repository content.",
+        ".project/worktrees/",
+        "",
+        "# Internal repos may keep workflow state, but raw browser artifacts stay local unless curated.",
+        ".project/logs/playwright/**/*.zip",
+        ".project/logs/playwright/**/*.webm",
+        ".project/logs/playwright/**/*.mp4",
+        ".project/logs/playwright/**/*.har",
+        ".project/logs/playwright/**/*.png",
+        ".project/logs/playwright/**/*.jpg",
+        ".project/logs/playwright/**/*.jpeg",
+        "playwright-report/",
+        "test-results/",
+    ],
+    "public": [
+        "# Public repos must not publish agent-private operational state by default.",
+        ".project/",
+        "AGENTS.local.md",
+        ".project.local/",
+        "",
+        "# Raw browser artifacts are local evidence, not public source material.",
+        "playwright-report/",
+        "test-results/",
+    ],
+}
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--visibility", choices=sorted(GITIGNORE_PROFILES), default="private")
+    parser.add_argument("--skip-gitignore", action="store_true")
     parser.add_argument("--force", action="store_true")
     return parser.parse_args()
 
@@ -27,11 +76,42 @@ def copy_tree(src_root: Path, dst_root: Path, force: bool) -> None:
         shutil.copyfile(src, dst)
 
 
+def artifact_policy_block(visibility: str) -> str:
+    lines = [BEGIN_MARKER, f"# Visibility profile: {visibility}"]
+    lines.extend(GITIGNORE_PROFILES[visibility])
+    lines.append(END_MARKER)
+    return "\n".join(lines) + "\n"
+
+
+def upsert_gitignore_policy(repo_root: Path, visibility: str) -> None:
+    gitignore = repo_root / ".gitignore"
+    block = artifact_policy_block(visibility)
+    if not gitignore.exists():
+        gitignore.write_text(block)
+        return
+
+    text = gitignore.read_text()
+    begin = text.find(BEGIN_MARKER)
+    end = text.find(END_MARKER)
+    if begin != -1 and end != -1 and begin < end:
+        end += len(END_MARKER)
+        new_text = text[:begin] + block.rstrip("\n") + text[end:]
+        if not new_text.endswith("\n"):
+            new_text += "\n"
+        gitignore.write_text(new_text)
+        return
+
+    separator = "" if text.endswith("\n\n") or text == "" else "\n"
+    gitignore.write_text(f"{text}{separator}{block}")
+
+
 def main() -> int:
     args = parse_args()
     skill_root = Path(__file__).resolve().parents[1]
     bootstrap_root = skill_root / "assets" / "bootstrap"
     copy_tree(bootstrap_root, args.repo_root, args.force)
+    if not args.skip_gitignore:
+        upsert_gitignore_policy(args.repo_root, args.visibility)
     return 0
 
 

--- a/skills/repo-bootstrap/SKILL.md
+++ b/skills/repo-bootstrap/SKILL.md
@@ -42,6 +42,7 @@ Do not use this skill when:
 - copy or adapt workflow templates into `.github/`
 - create or update `.project/blueprint/` baseline files
 - prepare CI and release workflow placeholders
+- choose and apply the repository visibility profile
 - document branch and release model
 - identify GitHub settings that must be applied to the existing remote
 - avoid overwriting existing project-specific conventions without explicit approval
@@ -60,6 +61,31 @@ Do not use this skill when:
 | Blueprint fit policy | `.project/blueprint/02_blueprint-fit-check.md` |
 | Verification policy | `.project/blueprint/03_verification-policy.md` |
 | Docker worktree policy | `.project/blueprint/04_docker-worktrees.md` |
+| Visibility artifact policy | marked Ora et Labora block in `.gitignore` |
+
+## Visibility Profiles
+
+Bootstrap must decide how workflow state is published before copying files.
+
+Use these profiles:
+
+| Profile | Use for | Publish by default | Keep local/ignored by default |
+| --- | --- | --- | --- |
+| `private` | private personal repos | `.project/blueprint/**`, `.project/todo/**`, concise `.project/logs/**`, `.github/**`, project `AGENTS.md` | `.project/worktrees/**`, raw Playwright traces/videos/HAR/screenshots, secrets |
+| `internal` | organization-internal repos | same as `private`, but written for broader internal readers | `.project/worktrees/**`, raw Playwright payloads, secrets, personal notes |
+| `public` | open source or public portfolio repos | `.github/**`, public docs, sanitized contributor-facing `AGENTS.md` only if useful | `.project/**`, `AGENTS.local.md`, local planning logs, raw Playwright payloads, private operating notes |
+
+If the remote exists, inspect visibility when practical:
+
+```bash
+gh repo view OWNER/REPO --json visibility
+```
+
+If there is no remote, or visibility cannot be determined, ask the user before applying a public/private/internal artifact policy.
+
+Public profile rule: `.project/` is local operational state by default. Do not commit it unless the user explicitly approves a sanitized subset. Stable guidance that public contributors need should move into normal public surfaces such as `CONTRIBUTING.md`, `SECURITY.md`, `docs/architecture.md`, `docs/testing.md`, and `docs/release.md`.
+
+Private/internal profile rule: `.project/` may be versioned, but raw browser artifacts remain controlled. Commit summaries and evidence paths; keep large Playwright traces, videos, HAR files, and screenshots ignored unless the repo explicitly curates them.
 
 ## Bootstrap Procedure
 
@@ -67,12 +93,15 @@ Do not use this skill when:
    - Read the closest `AGENTS.md`.
    - Check existing `.github/`, `.project/`, CI, release, Docker, and README conventions.
    - Identify whether the repo already uses `dev` and `main`.
+   - Identify the remote visibility when possible.
 2. Decide bootstrap mode.
    - Fresh repo: copy baseline templates.
    - Existing repo with partial workflow: merge carefully and preserve project-specific conventions.
    - Existing repo with conflicting workflow: stop and ask before changing branch model or overwriting policy.
+   - Choose `private`, `internal`, or `public` visibility profile.
 3. Copy templates.
    - Use `../ora-et-labora/scripts/bootstrap_repo_templates.py` when the baseline layout is acceptable.
+   - Pass `--visibility <profile>` so `.gitignore` receives the right artifact policy.
    - Use `--force` only when overwrite is explicitly intended.
 4. Adapt placeholders.
    - Replace example CI commands with project-specific commands.
@@ -85,6 +114,7 @@ Do not use this skill when:
    - Browser evidence path.
    - Docker worktree runtime rules.
    - Release flow from `dev` to `main`.
+   - For public repos, keep this local by default or translate sanitized content into public docs before committing.
 6. Apply GitHub defaults when a remote is present and the user approved settings changes.
    - Ensure `dev` exists.
    - Ensure `main` exists.
@@ -179,12 +209,29 @@ For frontend-capable repos, bootstrap should document:
 - Playwright artifacts belong under `.project/logs/playwright/<module-id>/<run-id>/`
 - PR templates must include a browser evidence field
 - CI should include smoke-level browser coverage when practical
+- raw Playwright payloads must follow the visibility profile instead of being committed casually
+
+For public repos, store local browser evidence while working but publish only safe summaries, CI links, or curated screenshots that do not reveal secrets, user data, private URLs, or internal implementation notes.
+
+## Public Repo Pre-Push Check
+
+Before the first push of a public bootstrap, inspect the diff for publishing risk:
+
+- no `.project/**` unless explicitly sanitized and approved
+- no private `AGENTS.md` instructions; use `AGENTS.local.md` for local-only rules
+- no secrets, tokens, private hostnames, account IDs, private paths, or screenshots with sensitive data
+- no raw Playwright traces, videos, HAR files, or screenshots unless intentionally curated
+- issue and PR templates contain public-safe language
+- CI placeholders do not reference private infrastructure
+- README and public docs explain only contributor-relevant workflow rules
 
 ## Red Flags - Stop Bootstrap
 
 - existing project workflow conflicts with Ora et Labora and the user has not approved migration
 - the user actually needs a new repository created, not an existing repository bootstrapped
 - templates would overwrite meaningful project-specific files
+- repo visibility is unknown and artifact publication policy matters
+- public bootstrap would commit `.project/`, private logs, or local-only agent instructions without explicit approval
 - CI placeholders look like real required gates but still contain fake commands
 - branch default is changed before `dev` exists
 - branch protection is claimed but not actually configured
@@ -196,10 +243,12 @@ For frontend-capable repos, bootstrap should document:
 | Excuse | Reality |
 | --- | --- |
 | "Templates are enough." | Bootstrap also needs branch model, blueprint docs, and GitHub settings plan. |
+| "Visibility is only a GitHub flag." | Visibility changes what workflow state can be safely committed. |
 | "We can configure GitHub later and say it is done." | Later is fine, but report it as pending, not complete. |
 | "The repo probably uses standard CI commands." | Inspect the project. Placeholder commands are not real gates. |
 | "Docker rules can stay in chat." | Runtime rules must be durable in `.project/blueprint/`. |
 | "Overwrite is faster." | Existing repo conventions may be intentional. Preserve or ask before overwriting. |
+| "The public repo can include everything because it is only process metadata." | `.project/` often contains private plans, paths, failures, screenshots, and operational assumptions. Keep it local or sanitize deliberately. |
 
 ## Templates And Tools
 
@@ -213,11 +262,13 @@ Use the script for baseline copying. Inspect and adapt the copied files before c
 - `.github/ISSUE_TEMPLATE/` present or intentionally skipped
 - `.github/PULL_REQUEST_TEMPLATE.md` present or intentionally skipped
 - PR template contains a linked issue / closing keyword section
+- visibility profile selected and represented in `.gitignore`
 - CI/release placeholders adapted or clearly marked
-- `.project/blueprint/` baseline present
+- `.project/blueprint/` baseline present for private/internal repos or intentionally local/sanitized for public repos
 - branch model documented
 - Docker worktree behavior documented when relevant
 - browser evidence policy documented for frontend projects
+- public repo pre-push check completed when visibility is public
 - GitHub default branch/ruleset status reported accurately
 - no unresolved placeholders remain in generated templates
 

--- a/skills/repo-init/SKILL.md
+++ b/skills/repo-init/SKILL.md
@@ -59,6 +59,7 @@ Required before remote creation:
 - owner: personal account or organization, such as `emmepra` or `my-org`
 - repo name
 - visibility: private, public, or internal
+- visibility profile: derived from visibility unless the user explicitly wants different artifact behavior
 - local path or parent folder
 - source mode
 - repo type
@@ -105,6 +106,22 @@ Choose exactly one source mode:
 
 Default to `new-empty` only when the user has not indicated an existing source.
 
+## Visibility Profiles
+
+Repository visibility is not only a GitHub setting. It controls which workflow artifacts are safe to publish.
+
+Use one of these profiles:
+
+| Profile | Default for | Versioned workflow state | Ignored/local workflow state |
+| --- | --- | --- | --- |
+| `private` | personal private repos | `.project/blueprint/**`, `.project/todo/**`, `.project/logs/**` summaries, `.github/**`, project `AGENTS.md` when useful | `.project/worktrees/**`, raw Playwright/browser payloads, secrets, `.env`, local-only overrides |
+| `internal` | organization-only repos | same as `private`, but assume broader internal readers and avoid personal/private notes | `.project/worktrees/**`, raw Playwright/browser payloads, secrets, local-only overrides |
+| `public` | open source or public portfolio repos | `.github/**`, sanitized public docs, optionally a short public `AGENTS.md` if contributor-safe | `.project/**` by default, `AGENTS.local.md`, local challenge logs, raw Playwright/browser payloads, private planning notes |
+
+For public repos, do not publish private agent operational state by default. Translate stable, contributor-useful knowledge into public docs such as `CONTRIBUTING.md`, `SECURITY.md`, `docs/architecture.md`, `docs/testing.md`, or `docs/release.md`. Keep `.project/` local unless the user intentionally approves a sanitized subset.
+
+For private and internal repos, `.project/` can be part of the repository because the workflow memory is useful to future agents. Even there, raw browser artifacts should be handled carefully: commit concise summaries and evidence paths; keep large traces, videos, HAR files, and screenshots local unless a project explicitly wants curated artifacts versioned.
+
 ## Confirmation Gate
 
 Repository creation is high-impact. Before running `gh repo create`, show the plan and ask for approval.
@@ -116,10 +133,12 @@ The confirmation must include:
 - local path
 - source mode
 - repo type
+- visibility profile and artifact publication policy
 - remote creation command shape
 - whether the first push will happen
 - branch model: `dev` default, `main` stable
 - whether Ora et Labora bootstrap files will be applied
+- whether `.project/`, `AGENTS.md`, and public docs will be versioned, local-only, or intentionally skipped
 - whether branch protection/rulesets will be configured now or recorded as pending
 
 Do not create the GitHub repo before this approval.
@@ -135,6 +154,7 @@ Do not create the GitHub repo before this approval.
    - Owner/org.
    - Repo name.
    - Visibility.
+   - Visibility profile.
    - Repo type.
    - Source mode.
    - Local path.
@@ -142,6 +162,7 @@ Do not create the GitHub repo before this approval.
 3. Produce the creation plan.
    - Keep it concrete.
    - Include the exact `OWNER/REPO`.
+   - Include the visibility profile and artifact policy.
    - Include commands to be run conceptually.
    - Ask for explicit approval before GitHub creation.
 4. Prepare the local repo.
@@ -161,8 +182,10 @@ Do not create the GitHub repo before this approval.
 7. Apply Ora et Labora workflow setup.
    - Copy or adapt issue templates.
    - Copy or adapt PR template.
-   - Copy or adapt `.project/blueprint/`.
+   - Copy or adapt `.project/blueprint/` for `private` and `internal` repos.
+   - For `public` repos, keep `.project/` local by default and translate stable guidance into public docs if requested.
    - Add CI/release placeholders appropriate for the repo type.
+   - Apply the profile-aware `.gitignore` policy with `bootstrap_repo_templates.py --visibility <profile>`.
    - Keep placeholders clearly marked until project-specific commands are known.
 8. Commit and push initial setup if approved.
    - Keep initial commit scoped to repo initialization.
@@ -276,6 +299,7 @@ If not configured:
 
 - owner/org is unclear
 - repo visibility is unclear
+- visibility profile or artifact publication policy is unclear
 - local path already exists and may be overwritten
 - remote repo may already exist
 - source mode is unclear
@@ -290,6 +314,7 @@ If not configured:
 | --- | --- |
 | "The owner is probably personal." | Ask or infer only if explicit context makes it safe. Wrong owner is costly. |
 | "Private is a safe default." | It is safer than public, but still ask if visibility was not specified. |
+| "Public can use the same `.project` policy as private." | Public repos need a publishing boundary. Keep agent-private state local unless explicitly sanitized. |
 | "I can create the repo and fix branches later." | Branch model is part of initialization. Plan it before creation. |
 | "Branch protection can be claimed from the template files." | Protection is a GitHub setting. Report it as pending unless configured. |
 | "Repo type does not matter yet." | Repo type determines templates, CI placeholders, verification policy, and browser evidence expectations. |
@@ -307,6 +332,7 @@ If not configured:
 - `main` stable branch exists when applicable
 - `dev` integration/default branch exists when applicable
 - Ora et Labora workflow files applied or intentionally deferred
+- visibility profile applied to `.gitignore` and workflow artifacts
 - initial commit/push completed or intentionally skipped
 - branch protection/ruleset status reported accurately
 - final response includes repo URL, local path, branch model, and pending steps
@@ -320,3 +346,4 @@ If not configured:
 - applying frontend CI placeholders to backend-only repos
 - forgetting to report branch protection as pending
 - overwriting an existing local folder without approval
+- publishing `.project/` or private planning logs in a public repo without explicit sanitization

--- a/tests/test_bootstrap_repo_templates.py
+++ b/tests/test_bootstrap_repo_templates.py
@@ -29,6 +29,63 @@ class BootstrapRepoTemplatesTests(unittest.TestCase):
             pr_template = (repo_root / ".github" / "PULL_REQUEST_TEMPLATE.md").read_text()
             self.assertIn("## Linked Issue", pr_template)
             self.assertIn("Closes #", pr_template)
+            gitignore = (repo_root / ".gitignore").read_text()
+            self.assertIn("Visibility profile: private", gitignore)
+            self.assertIn(".project/worktrees/", gitignore)
+            self.assertNotIn("\n.project/\n", f"\n{gitignore}")
+
+    def test_public_visibility_keeps_project_state_local(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            subprocess.run(
+                [
+                    "python",
+                    str(SCRIPT),
+                    "--repo-root",
+                    str(repo_root),
+                    "--visibility",
+                    "public",
+                ],
+                check=True,
+            )
+
+            gitignore = (repo_root / ".gitignore").read_text()
+            self.assertIn("Visibility profile: public", gitignore)
+            self.assertIn(".project/", gitignore)
+            self.assertIn("AGENTS.local.md", gitignore)
+            self.assertIn("playwright-report/", gitignore)
+
+    def test_visibility_policy_replaces_existing_block(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            subprocess.run(
+                [
+                    "python",
+                    str(SCRIPT),
+                    "--repo-root",
+                    str(repo_root),
+                    "--visibility",
+                    "private",
+                ],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "python",
+                    str(SCRIPT),
+                    "--repo-root",
+                    str(repo_root),
+                    "--visibility",
+                    "public",
+                    "--force",
+                ],
+                check=True,
+            )
+
+            gitignore = (repo_root / ".gitignore").read_text()
+            self.assertEqual(gitignore.count("BEGIN Ora et Labora artifact policy"), 1)
+            self.assertIn("Visibility profile: public", gitignore)
+            self.assertNotIn("Visibility profile: private", gitignore)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds public/private/internal visibility profiles to the Ora et Labora repo setup workflow.
- Updates `repo-init`, `repo-bootstrap`, and the suite index so artifact publication policy is explicit before setup.
- Extends `bootstrap_repo_templates.py` with `--visibility <private|internal|public>` and profile-aware `.gitignore` policy.
- Adds tests for private/default, public, and profile replacement behavior.

Closes #1

## Verification

- `python scripts/validate_all.py`

## Risk / Notes

- Public profile now ignores `.project/` by default, so public repos still get local Ora state but do not publish it unless deliberately sanitized.
- Private/internal profiles keep workflow memory versionable while ignoring worktrees and raw Playwright payloads.
