### PR TITLE
Harden issue and PR template enforcement

### DIFF
--- a/.project/logs/6-template-enforcement.md
+++ b/.project/logs/6-template-enforcement.md
@@ -3,3 +3,4 @@
 - 2026-04-24 | state:init | created issue #6 and worktree branch `feat/6-template-enforcement`
 - 2026-04-24 | verify:pass | added wrapper scripts, issue-template config, stronger skill wording, and enforcement tests; `python scripts/validate_all.py` passed
 - 2026-04-24 | pr:opened | opened PR #7 targeting `dev` using `create_pr_from_template.py`; PR body comes from the suite template
+- 2026-04-24 | pr:ready | PR #7 is rebased, issue-linked, locally verified, and waiting on current CI; auto-merge will be enabled if the check passes

--- a/.project/logs/6-template-enforcement.md
+++ b/.project/logs/6-template-enforcement.md
@@ -2,3 +2,4 @@
 
 - 2026-04-24 | state:init | created issue #6 and worktree branch `feat/6-template-enforcement`
 - 2026-04-24 | verify:pass | added wrapper scripts, issue-template config, stronger skill wording, and enforcement tests; `python scripts/validate_all.py` passed
+- 2026-04-24 | pr:opened | opened PR #7 targeting `dev` using `create_pr_from_template.py`; PR body comes from the suite template

--- a/.project/logs/6-template-enforcement.md
+++ b/.project/logs/6-template-enforcement.md
@@ -1,0 +1,4 @@
+# Template Enforcement Hardening Log
+
+- 2026-04-24 | state:init | created issue #6 and worktree branch `feat/6-template-enforcement`
+- 2026-04-24 | verify:pass | added wrapper scripts, issue-template config, stronger skill wording, and enforcement tests; `python scripts/validate_all.py` passed

--- a/.project/todo/6-template-enforcement/00_brainstorm.md
+++ b/.project/todo/6-template-enforcement/00_brainstorm.md
@@ -1,0 +1,21 @@
+# Template Enforcement Hardening
+
+## Problem
+
+Ora et Labora recommends issue/PR templates, but the creation path is still easy to bypass.
+
+## Decision
+
+Harden template usage in four places:
+
+- disable blank issues in bootstrapped repos
+- add dedicated helper scripts for issue and PR creation from templates
+- tighten skill wording so wrapper/body-file usage is the required path
+- add tests that protect these rules
+
+## Acceptance Checks
+
+- issue template config exists and disables blank issues
+- helper scripts render bodies and drive `gh ... --body-file`
+- skill docs point to the wrappers as the standard path
+- validation passes

--- a/.project/todo/6-template-enforcement/CURRENT.md
+++ b/.project/todo/6-template-enforcement/CURRENT.md
@@ -1,0 +1,29 @@
+# Current State - Template Enforcement Hardening
+
+## Issue
+
+https://github.com/emmepra/ora-et-labora/issues/6
+
+## Branch
+
+`feat/6-template-enforcement`
+
+## Worktree
+
+`.project/worktrees/feat-6-template-enforcement`
+
+## Status
+
+Implementation complete; PR pending.
+
+## Latest Verification
+
+`python scripts/validate_all.py` passed.
+
+## Next Step
+
+Commit, push, and open PR to `dev` using the PR wrapper script.
+
+## Blockers
+
+None.

--- a/.project/todo/6-template-enforcement/CURRENT.md
+++ b/.project/todo/6-template-enforcement/CURRENT.md
@@ -22,11 +22,11 @@ https://github.com/emmepra/ora-et-labora/pull/7
 
 ## Latest Verification
 
-`python scripts/validate_all.py` passed.
+`python scripts/validate_all.py` passed locally. GitHub `validate` is currently running on PR #7.
 
 ## Next Step
 
-Wait for CI and enable auto-merge if the gates pass.
+Auto-merge requested once the current `validate` check passes.
 
 ## Blockers
 

--- a/.project/todo/6-template-enforcement/CURRENT.md
+++ b/.project/todo/6-template-enforcement/CURRENT.md
@@ -14,7 +14,11 @@ https://github.com/emmepra/ora-et-labora/issues/6
 
 ## Status
 
-Implementation complete; PR pending.
+Implementation complete; PR open.
+
+## PR
+
+https://github.com/emmepra/ora-et-labora/pull/7
 
 ## Latest Verification
 
@@ -22,7 +26,7 @@ Implementation complete; PR pending.
 
 ## Next Step
 
-Commit, push, and open PR to `dev` using the PR wrapper script.
+Wait for CI and enable auto-merge if the gates pass.
 
 ## Blockers
 

--- a/.project/todo/6-template-enforcement/pr.md
+++ b/.project/todo/6-template-enforcement/pr.md
@@ -1,0 +1,43 @@
+## Summary
+
+- Adds dedicated issue and PR creation wrapper scripts.
+- Adds GitHub issue template config that disables blank issues in bootstrapped repos.
+- Tightens skill wording and tests so template usage is harder to bypass.
+
+## Why
+
+Template usage was recommended but still easy to bypass with raw gh commands. This change makes wrappers the standard path and adds tests that keep the policy in place.
+
+## Linked Issue
+
+Closes #6
+
+## Verification
+
+- Local: `python scripts/validate_all.py`
+- Browser: not applicable; process/docs/script-only change.
+- Browser evidence: not applicable.
+- CI: pending after PR creation.
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: yes, once required checks pass.
+- This is an implementation PR targeting `dev`.
+- Branch is rebased on `origin/dev`.
+- Browser verification is not applicable.
+- Branch-local `.project` state is current.
+
+## Blueprint Updates
+
+No blueprint files changed. This hardens workflow execution rules encoded in the skill suite itself.
+
+## Risks / Rollback
+
+Risk: stricter template usage may require agents to adopt the new wrappers.
+
+Rollback: revert this PR if the wrappers or issue-template config prove too rigid.
+
+## Follow-ups
+
+- After merge, sync installed local skills.
+- Optionally promote `dev` to `main` if you want the stable installer path updated.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The suite includes:
 - detailed self-contained `SKILL.md` bodies with procedure, red flags, rationalization counters, and completion checklists
 - issue, PR, release, brainstorm, current-state, and log templates
 - bootstrap assets for `.github/` and `.project/blueprint/`
-- helper scripts for template rendering, issue workspace initialization, visibility-aware bootstrap, and Playwright artifact collection
+- helper scripts for template rendering, issue/PR creation, issue workspace initialization, visibility-aware bootstrap, and Playwright artifact collection
 
 The operating procedure is intentionally inline in the skill files. Extra files are reserved for templates, scripts, bootstrap assets, tests, and examples.
 

--- a/skills/issue-shaping/SKILL.md
+++ b/skills/issue-shaping/SKILL.md
@@ -49,7 +49,7 @@ Do not use this skill for:
 - clarify the problem and intended outcome before code changes
 - capture constraints, non-goals, risks, unknowns, and acceptance checks
 - produce or update `.project/todo/<module-id>/00_brainstorm.md`
-- draft or refine the GitHub issue body using a template or body file
+- draft or refine the GitHub issue body using the issue wrapper or a rendered body file
 - identify the likely verification modalities early
 - leave a clean handoff for blueprint checking and worktree setup
 
@@ -112,7 +112,9 @@ If the same paragraph appears in all artifacts, the workflow is becoming redunda
 8. Draft or refine the GitHub issue body.
    - Use `issue-bug.md` for bugs.
    - Use `issue-feature.md` for features.
-   - Use a body file with `gh issue create --body-file <file>` when creating the issue.
+   - Standard path: use `../ora-et-labora/scripts/create_issue_from_template.py`.
+   - Minimum fallback: render a body file first, then use `gh issue create --body-file <file>`.
+   - Do not hand-write multi-section issue markdown directly into `gh issue create`.
 
 ## Output Contract
 
@@ -145,7 +147,7 @@ A shaped issue is ready only when:
 - acceptance checks are concrete
 - verification modalities are named
 - any suspected blueprint conflict is visible
-- the issue body is valid markdown rendered from a file or template
+- the issue body is valid markdown rendered through the wrapper script or a rendered template body file
 
 ## Red Flags - Stop Before Coding
 
@@ -208,8 +210,9 @@ Verification plan:
 - `../ora-et-labora/assets/templates/issue-bug.md`
 - `../ora-et-labora/assets/templates/issue-feature.md`
 - `../ora-et-labora/scripts/render_template.py`
+- `../ora-et-labora/scripts/create_issue_from_template.py`
 
-Use templates and rendered body files when producing GitHub issue markdown.
+Use the issue wrapper by default. Raw `gh issue create` is acceptable only when it still uses a rendered body file and the wrapper genuinely does not fit the operation.
 
 ## Handoff
 

--- a/skills/ora-et-labora/SKILL.md
+++ b/skills/ora-et-labora/SKILL.md
@@ -186,8 +186,10 @@ Use templates and body files for complex GitHub markdown.
 
 Use:
 
-- `gh issue create --body-file <file>`
-- `gh pr create --body-file <file>`
+- `create_issue_from_template.py` for issue creation
+- `create_pr_from_template.py` for PR creation
+- `gh issue create --body-file <file>` only as a fallback after rendering a body file
+- `gh pr create --body-file <file>` only as a fallback after rendering a body file
 
 Avoid:
 
@@ -215,6 +217,8 @@ Use these rather than recreating structure from memory.
 Scripts live under `scripts/`:
 
 - `render_template.py`: render markdown templates with strict placeholder replacement.
+- `create_issue_from_template.py`: render an issue template and create the GitHub issue from the body file.
+- `create_pr_from_template.py`: render a PR template and create the GitHub PR from the body file.
 - `init_issue_workspace.py`: initialize `00_brainstorm.md`, `CURRENT.md`, and task log.
 - `bootstrap_repo_templates.py`: copy GitHub templates, blueprint docs, and workflow examples into a target repo.
 - `bootstrap_repo_templates.py --visibility <profile>`: also writes the profile-aware artifact policy into `.gitignore`.
@@ -229,6 +233,7 @@ Prefer scripts for deterministic file layout and template rendering.
 - "I will use one log file for every branch."
 - "I will open a PR to `main` for normal feature work."
 - "I will open the PR without `Closes #<issue>` and close the issue manually later."
+- "I will skip the wrapper script and hand-write the issue or PR body inline."
 - "I will enable auto-merge without checking CI, reviews, branch freshness, and task state."
 - "I will auto-merge the release PR into `main` because checks are green."
 - "I will publish `.project/` in a public repo because it is only process state."

--- a/skills/ora-et-labora/assets/bootstrap/.github/ISSUE_TEMPLATE/config.yml
+++ b/skills/ora-et-labora/assets/bootstrap/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/skills/ora-et-labora/scripts/create_issue_from_template.py
+++ b/skills/ora-et-labora/scripts/create_issue_from_template.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Render an issue template and create a GitHub issue from the body file."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from render_template import parse_vars, render
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--template", type=Path, required=True)
+    parser.add_argument("--body-out", type=Path, required=True)
+    parser.add_argument("--label", action="append", default=[])
+    parser.add_argument("--var", action="append", default=[], metavar="KEY=VALUE")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    body = render(args.template.read_text(), parse_vars(args.var))
+    args.body_out.parent.mkdir(parents=True, exist_ok=True)
+    args.body_out.write_text(body)
+
+    if args.dry_run:
+        print(args.body_out)
+        return 0
+
+    cmd = [
+        "gh",
+        "issue",
+        "create",
+        "--repo",
+        args.repo,
+        "--title",
+        args.title,
+        "--body-file",
+        str(args.body_out),
+    ]
+    for label in args.label:
+        cmd.extend(["--label", label])
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    print(result.stdout.strip())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ora-et-labora/scripts/create_pr_from_template.py
+++ b/skills/ora-et-labora/scripts/create_pr_from_template.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Render a PR template and create a GitHub pull request from the body file."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from render_template import parse_vars, render
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--template", type=Path, required=True)
+    parser.add_argument("--body-out", type=Path, required=True)
+    parser.add_argument("--var", action="append", default=[], metavar="KEY=VALUE")
+    parser.add_argument("--draft", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    body = render(args.template.read_text(), parse_vars(args.var))
+    args.body_out.parent.mkdir(parents=True, exist_ok=True)
+    args.body_out.write_text(body)
+
+    if args.dry_run:
+        print(args.body_out)
+        return 0
+
+    cmd = [
+        "gh",
+        "pr",
+        "create",
+        "--repo",
+        args.repo,
+        "--base",
+        args.base,
+        "--head",
+        args.head,
+        "--title",
+        args.title,
+        "--body-file",
+        str(args.body_out),
+    ]
+    if args.draft:
+        cmd.append("--draft")
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    print(result.stdout.strip())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/repo-bootstrap/SKILL.md
+++ b/skills/repo-bootstrap/SKILL.md
@@ -53,6 +53,7 @@ Do not use this skill when:
 | --- | --- |
 | Bug issue template | `.github/ISSUE_TEMPLATE/bug_report.md` |
 | Feature issue template | `.github/ISSUE_TEMPLATE/feature_request.md` |
+| Issue template config | `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false` |
 | PR template | `.github/PULL_REQUEST_TEMPLATE.md` with a `Linked Issue` / `Closes #` section |
 | CI placeholder | `.github/workflows/ci.yml.example` |
 | Release placeholder | `.github/workflows/release.yml.example` |
@@ -174,6 +175,7 @@ Issue and PR formatting should be deterministic.
 Use:
 
 - templates under `.github/`
+- issue template config under `.github/ISSUE_TEMPLATE/config.yml`
 - body files
 - `gh issue create --body-file <file>`
 - `gh pr create --body-file <file>`
@@ -260,6 +262,7 @@ Use the script for baseline copying. Inspect and adapt the copied files before c
 
 - existing repo workflow inspected
 - `.github/ISSUE_TEMPLATE/` present or intentionally skipped
+- `.github/ISSUE_TEMPLATE/config.yml` disables blank issues unless intentionally overridden
 - `.github/PULL_REQUEST_TEMPLATE.md` present or intentionally skipped
 - PR template contains a linked issue / closing keyword section
 - visibility profile selected and represented in `.gitignore`

--- a/skills/worktree-flow/SKILL.md
+++ b/skills/worktree-flow/SKILL.md
@@ -96,7 +96,9 @@ Worktree folder names should avoid slashes:
    - Write `.project/todo`, `.project/logs`, and `.project/blueprint` in the assigned worktree checkout for branch work.
 6. Open a draft PR early when the branch will be active for more than a tiny fix.
    - Base: `dev`.
-   - Use a body file or template, not inline shell markdown.
+   - Standard path: use `../ora-et-labora/scripts/create_pr_from_template.py`.
+   - Minimum fallback: render a body file first, then use `gh pr create --body-file <file>`.
+   - Do not hand-write multi-section PR markdown directly into `gh pr create`.
    - Include `Closes #<issue-id>` or an equivalent GitHub closing keyword for the originating issue.
 7. Rebase on `origin/dev` at required gates.
    - At session start in that worktree.
@@ -122,7 +124,7 @@ Before marking a PR ready:
 - browser evidence exists for frontend behavior changes
 - Docker/runtime state was rebuilt or restarted after sync when relevant
 - PR body contains a closing reference to the originating issue, such as `Closes #123`
-- PR body is rendered from a body file or template
+- PR body is rendered through the wrapper script or from a rendered body file
 - branch-local `.project` state points to the PR
 
 ## Auto-Merge Policy
@@ -248,7 +250,7 @@ All of these mean the branch/worktree flow is unsafe.
 - Docker mode is clear: default one-stack or isolated parallel mode
 - PR targets `dev`
 - PR body uses `Closes #<issue-id>` or an equivalent closing keyword for the originating issue
-- PR body comes from a file or template
+- PR body comes from `create_pr_from_template.py` or a rendered body file
 - verification is complete before PR readiness
 - auto-merge is enabled only for eligible `dev` PRs, or explicitly skipped/blocked in the task log
 

--- a/tests/test_bootstrap_repo_templates.py
+++ b/tests/test_bootstrap_repo_templates.py
@@ -25,10 +25,13 @@ class BootstrapRepoTemplatesTests(unittest.TestCase):
             )
 
             self.assertTrue((repo_root / ".github" / "PULL_REQUEST_TEMPLATE.md").exists())
+            self.assertTrue((repo_root / ".github" / "ISSUE_TEMPLATE" / "config.yml").exists())
             self.assertTrue((repo_root / ".project" / "blueprint" / "00_workflow.md").exists())
             pr_template = (repo_root / ".github" / "PULL_REQUEST_TEMPLATE.md").read_text()
+            issue_config = (repo_root / ".github" / "ISSUE_TEMPLATE" / "config.yml").read_text()
             self.assertIn("## Linked Issue", pr_template)
             self.assertIn("Closes #", pr_template)
+            self.assertIn("blank_issues_enabled: false", issue_config)
             gitignore = (repo_root / ".gitignore").read_text()
             self.assertIn("Visibility profile: private", gitignore)
             self.assertIn(".project/worktrees/", gitignore)

--- a/tests/test_create_issue_from_template.py
+++ b/tests/test_create_issue_from_template.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "skills" / "ora-et-labora" / "scripts" / "create_issue_from_template.py"
+
+
+class CreateIssueFromTemplateTests(unittest.TestCase):
+    def test_renders_issue_body_in_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            template = tmpdir / "issue.md"
+            body_out = tmpdir / "body.md"
+            template.write_text("Problem: {{PROBLEM}}\n")
+            subprocess.run(
+                [
+                    "python",
+                    str(SCRIPT),
+                    "--repo",
+                    "owner/repo",
+                    "--title",
+                    "Example issue",
+                    "--template",
+                    str(template),
+                    "--body-out",
+                    str(body_out),
+                    "--var",
+                    "PROBLEM=missing template enforcement",
+                    "--dry-run",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(body_out.read_text(), "Problem: missing template enforcement\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_create_pr_from_template.py
+++ b/tests/test_create_pr_from_template.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "skills" / "ora-et-labora" / "scripts" / "create_pr_from_template.py"
+
+
+class CreatePrFromTemplateTests(unittest.TestCase):
+    def test_renders_pr_body_in_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            template = tmpdir / "pr.md"
+            body_out = tmpdir / "body.md"
+            template.write_text("Summary: {{SUMMARY}}\n")
+            subprocess.run(
+                [
+                    "python",
+                    str(SCRIPT),
+                    "--repo",
+                    "owner/repo",
+                    "--title",
+                    "Example pr",
+                    "--base",
+                    "dev",
+                    "--head",
+                    "feat/example",
+                    "--template",
+                    str(template),
+                    "--body-out",
+                    str(body_out),
+                    "--var",
+                    "SUMMARY=template-enforced pr",
+                    "--dry-run",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(body_out.read_text(), "Summary: template-enforced pr\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_template_enforcement_policy.py
+++ b/tests/test_template_enforcement_policy.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TemplateEnforcementPolicyTests(unittest.TestCase):
+    def test_issue_shaping_requires_issue_wrapper(self) -> None:
+        text = (REPO_ROOT / "skills" / "issue-shaping" / "SKILL.md").read_text()
+        self.assertIn("create_issue_from_template.py", text)
+
+    def test_worktree_flow_requires_pr_wrapper(self) -> None:
+        text = (REPO_ROOT / "skills" / "worktree-flow" / "SKILL.md").read_text()
+        self.assertIn("create_pr_from_template.py", text)
+
+    def test_suite_index_mentions_issue_and_pr_wrappers(self) -> None:
+        text = (REPO_ROOT / "skills" / "ora-et-labora" / "SKILL.md").read_text()
+        self.assertIn("create_issue_from_template.py", text)
+        self.assertIn("create_pr_from_template.py", text)
+
+    def test_wrapper_scripts_use_body_file_creation(self) -> None:
+        issue_script = (
+            REPO_ROOT / "skills" / "ora-et-labora" / "scripts" / "create_issue_from_template.py"
+        ).read_text()
+        pr_script = (
+            REPO_ROOT / "skills" / "ora-et-labora" / "scripts" / "create_pr_from_template.py"
+        ).read_text()
+        self.assertIn("--body-file", issue_script)
+        self.assertIn("--body-file", pr_script)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds dedicated issue and PR creation wrapper scripts.
- Adds GitHub issue template config that disables blank issues in bootstrapped repos.
- Tightens skill wording and tests so template usage is harder to bypass.

## Why

Template usage was recommended but still easy to bypass with raw gh commands. This change makes wrappers the standard path and adds tests that keep the policy in place.

## Linked Issue

Closes #6

## Verification

- Local: `python scripts/validate_all.py`
- Browser: not applicable; process/docs/script-only change.
- Browser evidence: not applicable.
- CI: pending after PR creation.

## Auto-Merge Eligibility

- Agent auto-merge requested: yes, once required checks pass.
- This is an implementation PR targeting `dev`.
- Branch is rebased on `origin/dev`.
- Browser verification is not applicable.
- Branch-local `.project` state is current.

## Blueprint Updates

No blueprint files changed. This hardens workflow execution rules encoded in the skill suite itself.

## Risks / Rollback

Risk: stricter template usage may require agents to adopt the new wrappers.

Rollback: revert this PR if the wrappers or issue-template config prove too rigid.

## Follow-ups

- After merge, sync installed local skills.
- Optionally promote `dev` to `main` if you want the stable installer path updated.
