### PR TITLE
Enforce PR body structure in CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,5 +23,10 @@ jobs:
           mkdir -p "$HOME/.codex/skills/.system"
           rm -rf "$HOME/.codex/skills/.system/skill-creator"
           cp -R /tmp/openai-skills/skills/.system/skill-creator "$HOME/.codex/skills/.system/skill-creator"
+      - name: Validate PR body
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+        run: python scripts/validate_pr_body.py --body "$PR_BODY"
       - name: Validate suite
         run: python scripts/validate_all.py

--- a/.project/logs/8.md
+++ b/.project/logs/8.md
@@ -1,0 +1,5 @@
+# Task Log: 8
+
+- 2026-04-24 | state:init | branch:feat/8-pr-body-validation | issue:#8 | note:Workspace initialized.
+- 2026-04-24 | verify:local-pass | command:`python scripts/validate_all.py` | note:20 tests passed and all skills validated after adding the PR body gate.
+- 2026-04-24 | verify:contract-pass | command:`python scripts/validate_pr_body.py --body-file .project/todo/6-template-enforcement/pr.md` | note:Validator accepts the canonical rendered PR structure.

--- a/.project/todo/8/00_brainstorm.md
+++ b/.project/todo/8/00_brainstorm.md
@@ -1,0 +1,41 @@
+# Add PR body validation gate: Brainstorm
+
+- Date: 2026-04-24
+- Issue: [#8](https://github.com/emmepra/ora-et-labora/issues/8)
+- Kind: feature
+- Module: 8
+
+## Problem
+
+- 
+
+## Desired Outcome
+
+- 
+
+## Constraints
+
+- 
+
+## Blueprint Fit Check
+
+- Relevant blueprint docs:
+- Feasibility:
+- Conflicts or missing decisions:
+
+## Options Considered
+
+- Option A:
+- Option B:
+
+## Chosen Direction
+
+- 
+
+## Risks / Unknowns
+
+- 
+
+## Acceptance Checks
+
+- 

--- a/.project/todo/8/CURRENT.md
+++ b/.project/todo/8/CURRENT.md
@@ -1,0 +1,14 @@
+# Current State
+
+- Issue: [#8](https://github.com/emmepra/ora-et-labora/issues/8)
+- Title: Add PR body validation gate
+- Kind: feature
+- Module: 8
+- Branch: feat/8-pr-body-validation
+- Status: implementation complete; ready to open PR
+- PR: pending
+- Last verification: `python scripts/validate_all.py` passed; `python scripts/validate_pr_body.py --body-file .project/todo/6-template-enforcement/pr.md` passed
+- Browser evidence: not applicable
+- Next step: commit, push, and open the PR to `dev`; then enable auto-merge once required checks are pending/passing
+- Blockers: none
+- Files touched: `.github/workflows/validate.yml`, `README.md`, `skills/worktree-flow/SKILL.md`, `scripts/validate_pr_body.py`, `tests/test_template_enforcement_policy.py`, `tests/test_validate_pr_body.py`

--- a/.project/todo/8/pr.md
+++ b/.project/todo/8/pr.md
@@ -1,0 +1,43 @@
+## Summary
+
+- Adds a PR body validation script that enforces the Ora et Labora PR template contract.
+- Runs the new gate in GitHub `validate` on every pull request before suite validation.
+- Adds tests for valid PR bodies, missing sections, missing `Closes #` references, and unresolved placeholders.
+
+## Why
+
+The template wrappers and GitHub issue config hardened issue and PR creation, but malformed PR bodies could still slip through if an agent bypassed the standard rendering path. This adds the missing CI-side enforcement so PR template structure becomes a real gate.
+
+## Linked Issue
+
+Closes #8
+
+## Verification
+
+- Local: `python scripts/validate_all.py`; `python scripts/validate_pr_body.py --body-file .project/todo/6-template-enforcement/pr.md`
+- Browser: not applicable; workflow/docs/script-only change.
+- Browser evidence: not applicable.
+- CI: pending after PR creation.
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: yes, once required checks pass.
+- This is an implementation PR targeting `dev`.
+- Branch is rebased on `origin/dev`.
+- Browser verification is not applicable.
+- Branch-local `.project` state is current.
+
+## Blueprint Updates
+
+No blueprint files changed. This extends the template-enforcement workflow already added to the suite by making PR body structure enforceable in CI.
+
+## Risks / Rollback
+
+Risk: the validator could be too strict and reject legitimate PR bodies if the template contract changes without updating the script.
+
+Rollback: revert this PR to remove the CI gate and validator if it blocks valid workflow.
+
+## Follow-ups
+
+- After merge, sync installed local skills.
+- If desired later, add a similar review-time gate for issue bodies, though GitHub issue templates and wrapper usage already cover most of that path.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The suite includes:
 - issue, PR, release, brainstorm, current-state, and log templates
 - bootstrap assets for `.github/` and `.project/blueprint/`
 - helper scripts for template rendering, issue/PR creation, issue workspace initialization, visibility-aware bootstrap, and Playwright artifact collection
+- a CI gate that rejects malformed PR bodies that do not satisfy the suite PR template contract
 
 The operating procedure is intentionally inline in the skill files. Extra files are reserved for templates, scripts, bootstrap assets, tests, and examples.
 

--- a/scripts/validate_pr_body.py
+++ b/scripts/validate_pr_body.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Validate a PR body against the Ora et Labora PR template contract."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+PLACEHOLDER_RE = re.compile(r"\{\{[^}]+\}\}")
+REQUIRED_VERIFICATION_PREFIXES = (
+    "- Local:",
+    "- Browser:",
+    "- Browser evidence:",
+    "- CI:",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--body-file", type=Path)
+    group.add_argument("--body")
+    parser.add_argument("--template", type=Path)
+    return parser.parse_args()
+
+
+def load_body(args: argparse.Namespace) -> str:
+    if args.body_file is not None:
+        return args.body_file.read_text()
+    return args.body
+
+
+def load_required_headers(template_path: Path) -> list[str]:
+    return [line.strip() for line in template_path.read_text().splitlines() if line.startswith("## ")]
+
+
+def extract_sections(body: str) -> dict[str, str]:
+    sections: dict[str, str] = {}
+    current_header: Optional[str] = None
+    current_lines: list[str] = []
+
+    for line in body.splitlines():
+        if line.startswith("## "):
+            if current_header is not None:
+                sections[current_header] = "\n".join(current_lines).strip()
+            current_header = line.strip()
+            current_lines = []
+            continue
+        if current_header is not None:
+            current_lines.append(line)
+
+    if current_header is not None:
+        sections[current_header] = "\n".join(current_lines).strip()
+    return sections
+
+
+def validate_body(body: str, template_path: Path) -> list[str]:
+    errors: list[str] = []
+
+    placeholders = sorted(set(PLACEHOLDER_RE.findall(body)))
+    if placeholders:
+        errors.append(
+            "PR body contains unresolved template placeholders: " + ", ".join(placeholders)
+        )
+
+    sections = extract_sections(body)
+    required_headers = load_required_headers(template_path)
+    for header in required_headers:
+        if header not in sections:
+            errors.append(f"Missing required section header: {header}")
+            continue
+        if not sections[header]:
+            errors.append(f"Section is empty: {header}")
+
+    linked_issue = sections.get("## Linked Issue", "")
+    if linked_issue and not re.search(r"(?im)\bcloses\s+#\d+\b", linked_issue):
+        errors.append("Linked Issue section must contain a `Closes #<issue>` reference.")
+
+    verification = sections.get("## Verification", "")
+    for prefix in REQUIRED_VERIFICATION_PREFIXES:
+        if verification and prefix not in verification:
+            errors.append(f"Verification section is missing required line prefix: {prefix}")
+
+    return errors
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    template_path = args.template or repo_root / "skills" / "ora-et-labora" / "assets" / "templates" / "pr.md"
+    body = load_body(args)
+    errors = validate_body(body, template_path)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print("PR body matches the Ora et Labora template contract.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/worktree-flow/SKILL.md
+++ b/skills/worktree-flow/SKILL.md
@@ -250,7 +250,8 @@ All of these mean the branch/worktree flow is unsafe.
 - Docker mode is clear: default one-stack or isolated parallel mode
 - PR targets `dev`
 - PR body uses `Closes #<issue-id>` or an equivalent closing keyword for the originating issue
-- PR body comes from `create_pr_from_template.py` or a rendered body file
+   - PR body comes from `create_pr_from_template.py` or a rendered body file
+   - GitHub `validate` rejects PRs whose bodies are missing required template sections or the `Closes #<issue>` reference
 - verification is complete before PR readiness
 - auto-merge is enabled only for eligible `dev` PRs, or explicitly skipped/blocked in the task log
 

--- a/tests/test_template_enforcement_policy.py
+++ b/tests/test_template_enforcement_policy.py
@@ -31,6 +31,11 @@ class TemplateEnforcementPolicyTests(unittest.TestCase):
         self.assertIn("--body-file", issue_script)
         self.assertIn("--body-file", pr_script)
 
+    def test_validate_workflow_runs_pr_body_gate(self) -> None:
+        workflow = (REPO_ROOT / ".github" / "workflows" / "validate.yml").read_text()
+        self.assertIn("Validate PR body", workflow)
+        self.assertIn("scripts/validate_pr_body.py", workflow)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validate_pr_body.py
+++ b/tests/test_validate_pr_body.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "validate_pr_body.py"
+SPEC = importlib.util.spec_from_file_location("validate_pr_body", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC is not None and SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+validate_body = MODULE.validate_body
+
+
+class ValidatePrBodyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.template = REPO_ROOT / "skills" / "ora-et-labora" / "assets" / "templates" / "pr.md"
+
+    def test_accepts_valid_body(self) -> None:
+        body = """## Summary
+
+- Adds a PR body validation gate.
+
+## Why
+
+This makes template structure a real CI requirement.
+
+## Linked Issue
+
+Closes #8
+
+## Verification
+
+- Local: `python scripts/validate_all.py`
+- Browser: not applicable
+- Browser evidence: not applicable
+- CI: pending after PR creation
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: yes, once required checks pass.
+
+## Blueprint Updates
+
+No blueprint updates required.
+
+## Risks / Rollback
+
+Rollback: revert this PR.
+
+## Follow-ups
+
+- Sync installed skills after merge.
+"""
+        self.assertEqual(validate_body(body, self.template), [])
+
+    def test_rejects_missing_section(self) -> None:
+        body = """## Summary
+
+- Adds a PR body validation gate.
+
+## Linked Issue
+
+Closes #8
+
+## Verification
+
+- Local: `python scripts/validate_all.py`
+- Browser: not applicable
+- Browser evidence: not applicable
+- CI: pending after PR creation
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: yes, once required checks pass.
+
+## Blueprint Updates
+
+No blueprint updates required.
+
+## Risks / Rollback
+
+Rollback: revert this PR.
+
+## Follow-ups
+
+- Sync installed skills after merge.
+"""
+        errors = validate_body(body, self.template)
+        self.assertIn("Missing required section header: ## Why", errors)
+
+    def test_rejects_missing_closes_reference(self) -> None:
+        body = """## Summary
+
+- Adds a PR body validation gate.
+
+## Why
+
+This makes template structure a real CI requirement.
+
+## Linked Issue
+
+References #8
+
+## Verification
+
+- Local: `python scripts/validate_all.py`
+- Browser: not applicable
+- Browser evidence: not applicable
+- CI: pending after PR creation
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: yes, once required checks pass.
+
+## Blueprint Updates
+
+No blueprint updates required.
+
+## Risks / Rollback
+
+Rollback: revert this PR.
+
+## Follow-ups
+
+- Sync installed skills after merge.
+"""
+        errors = validate_body(body, self.template)
+        self.assertIn("Linked Issue section must contain a `Closes #<issue>` reference.", errors)
+
+    def test_rejects_unresolved_placeholders(self) -> None:
+        body = """## Summary
+
+{{SUMMARY}}
+
+## Why
+
+This makes template structure a real CI requirement.
+
+## Linked Issue
+
+Closes #8
+
+## Verification
+
+- Local: `python scripts/validate_all.py`
+- Browser: not applicable
+- Browser evidence: not applicable
+- CI: pending after PR creation
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: yes, once required checks pass.
+
+## Blueprint Updates
+
+No blueprint updates required.
+
+## Risks / Rollback
+
+Rollback: revert this PR.
+
+## Follow-ups
+
+- Sync installed skills after merge.
+"""
+        errors = validate_body(body, self.template)
+        self.assertEqual(
+            errors[0],
+            "PR body contains unresolved template placeholders: {{SUMMARY}}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a PR body validation script that enforces the Ora et Labora PR template contract.
- Runs the new gate in GitHub `validate` on every pull request before suite validation.
- Adds tests for valid PR bodies, missing sections, missing `Closes #` references, and unresolved placeholders.

## Why

The template wrappers and GitHub issue config hardened issue and PR creation, but malformed PR bodies could still slip through if an agent bypassed the standard rendering path. This adds the missing CI-side enforcement so PR template structure becomes a real gate.

## Linked Issue

Closes #8

## Verification

- Local: `python scripts/validate_all.py`; `python scripts/validate_pr_body.py --body-file .project/todo/6-template-enforcement/pr.md`
- Browser: not applicable; workflow/docs/script-only change.
- Browser evidence: not applicable.
- CI: pending after PR creation.

## Auto-Merge Eligibility

- Agent auto-merge requested: yes, once required checks pass.
- This is an implementation PR targeting `dev`.
- Branch is rebased on `origin/dev`.
- Browser verification is not applicable.
- Branch-local `.project` state is current.

## Blueprint Updates

No blueprint files changed. This extends the template-enforcement workflow already added to the suite by making PR body structure enforceable in CI.

## Risks / Rollback

Risk: the validator could be too strict and reject legitimate PR bodies if the template contract changes without updating the script.

Rollback: revert this PR to remove the CI gate and validator if it blocks valid workflow.

## Follow-ups

- After merge, sync installed local skills.
- If desired later, add a similar review-time gate for issue bodies, though GitHub issue templates and wrapper usage already cover most of that path.
