### PR TITLE
Propagate PR body validation through bootstrap assets

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,6 +27,6 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           PR_BODY: ${{ github.event.pull_request.body || '' }}
-        run: python scripts/validate_pr_body.py --body "$PR_BODY"
+        run: python skills/ora-et-labora/scripts/validate_pr_body.py --body "$PR_BODY"
       - name: Validate suite
         run: python scripts/validate_all.py

--- a/.project/logs/10.md
+++ b/.project/logs/10.md
@@ -1,0 +1,5 @@
+# Task Log: 10
+
+- 2026-04-24 | state:init | branch:feat/10-bootstrap-pr-body-validation | issue:#10 | note:Workspace initialized.
+- 2026-04-24 | verify:local-pass | command:`python scripts/validate_all.py` | note:21 tests passed and all skills validated after moving the PR validator into the shipped skill payload.
+- 2026-04-24 | verify:bootstrap-smoke-pass | command:`python scripts/validate_pr_body.py --body-file <bootstrapped-body>` | note:Bootstrapped repos receive a runnable validator plus standalone PR-body workflow asset.

--- a/.project/todo/10/00_brainstorm.md
+++ b/.project/todo/10/00_brainstorm.md
@@ -1,0 +1,41 @@
+# Propagate PR body validation through bootstrap assets: Brainstorm
+
+- Date: 2026-04-24
+- Issue: [#10](https://github.com/emmepra/ora-et-labora/issues/10)
+- Kind: feature
+- Module: 10
+
+## Problem
+
+- 
+
+## Desired Outcome
+
+- 
+
+## Constraints
+
+- 
+
+## Blueprint Fit Check
+
+- Relevant blueprint docs:
+- Feasibility:
+- Conflicts or missing decisions:
+
+## Options Considered
+
+- Option A:
+- Option B:
+
+## Chosen Direction
+
+- 
+
+## Risks / Unknowns
+
+- 
+
+## Acceptance Checks
+
+- 

--- a/.project/todo/10/CURRENT.md
+++ b/.project/todo/10/CURRENT.md
@@ -1,0 +1,14 @@
+# Current State
+
+- Issue: [#10](https://github.com/emmepra/ora-et-labora/issues/10)
+- Title: Propagate PR body validation through bootstrap assets
+- Kind: feature
+- Module: 10
+- Branch: feat/10-bootstrap-pr-body-validation
+- Status: implementation complete; ready to open PR
+- PR: pending
+- Last verification: `python scripts/validate_all.py` passed; skill-owned validator and bootstrapped-copy smoke checks passed
+- Browser evidence: not applicable
+- Next step: commit, push, and open the PR to `dev`; then enable auto-merge once required checks are pending/passing
+- Blockers: none
+- Files touched: `.github/workflows/validate.yml`, `scripts/validate_pr_body.py`, `skills/ora-et-labora/SKILL.md`, `skills/ora-et-labora/scripts/bootstrap_repo_templates.py`, `skills/ora-et-labora/scripts/validate_pr_body.py`, `skills/ora-et-labora/assets/bootstrap/.github/workflows/validate-pr-body.yml`, `skills/repo-bootstrap/SKILL.md`, `tests/test_bootstrap_repo_templates.py`, `tests/test_template_enforcement_policy.py`, `tests/test_validate_pr_body.py`

--- a/.project/todo/10/pr.md
+++ b/.project/todo/10/pr.md
@@ -1,0 +1,43 @@
+## Summary
+
+- Moves the PR body validator into the shipped `ora-et-labora` skill so installed skills carry the logic.
+- Makes bootstrap copy the validator into target repos and adds a standalone `validate-pr-body.yml` workflow asset.
+- Adjusts tests and repo docs so the bootstrap payload, installed skill, and suite repo all enforce the same PR body contract.
+
+## Why
+
+The previous PR added PR-body validation for the suite repo itself, but the validator lived only at repo root. That meant installed skills did not contain it, and bootstrapped repos did not inherit the enforcement automatically. This closes that propagation gap.
+
+## Linked Issue
+
+Closes #10
+
+## Verification
+
+- Local: `python scripts/validate_all.py`; `python skills/ora-et-labora/scripts/validate_pr_body.py --body-file .project/todo/8/pr.md`
+- Browser: not applicable; workflow/docs/script-only change.
+- Browser evidence: not applicable.
+- CI: pending after PR creation.
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: yes, once required checks pass.
+- This is an implementation PR targeting `dev`.
+- Branch is rebased on `origin/dev`.
+- Browser verification is not applicable.
+- Branch-local `.project` state is current.
+
+## Blueprint Updates
+
+No blueprint files changed. This is a packaging and bootstrap-propagation fix for the template enforcement already added to the suite.
+
+## Risks / Rollback
+
+Risk: path resolution between skill-source usage and copied-into-repo usage could drift again if future template locations change.
+
+Rollback: revert this PR to return to the repo-root-only validator model.
+
+## Follow-ups
+
+- After merge, sync installed local skills again so the shipped validator is present under `~/.codex/skills/ora-et-labora/scripts/`.
+- If needed later, fold the standalone PR-body workflow into project-specific CI after bootstrap, but keep an equivalent gate in place.

--- a/scripts/validate_pr_body.py
+++ b/scripts/validate_pr_body.py
@@ -1,107 +1,24 @@
 #!/usr/bin/env python3
-"""Validate a PR body against the Ora et Labora PR template contract."""
+"""Convenience wrapper for the skill-owned PR body validator."""
 
 from __future__ import annotations
 
-import argparse
-import re
-import sys
+import importlib.util
 from pathlib import Path
-from typing import Optional
 
 
-PLACEHOLDER_RE = re.compile(r"\{\{[^}]+\}\}")
-REQUIRED_VERIFICATION_PREFIXES = (
-    "- Local:",
-    "- Browser:",
-    "- Browser evidence:",
-    "- CI:",
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "ora-et-labora"
+    / "scripts"
+    / "validate_pr_body.py"
 )
-
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=__doc__)
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--body-file", type=Path)
-    group.add_argument("--body")
-    parser.add_argument("--template", type=Path)
-    return parser.parse_args()
-
-
-def load_body(args: argparse.Namespace) -> str:
-    if args.body_file is not None:
-        return args.body_file.read_text()
-    return args.body
-
-
-def load_required_headers(template_path: Path) -> list[str]:
-    return [line.strip() for line in template_path.read_text().splitlines() if line.startswith("## ")]
-
-
-def extract_sections(body: str) -> dict[str, str]:
-    sections: dict[str, str] = {}
-    current_header: Optional[str] = None
-    current_lines: list[str] = []
-
-    for line in body.splitlines():
-        if line.startswith("## "):
-            if current_header is not None:
-                sections[current_header] = "\n".join(current_lines).strip()
-            current_header = line.strip()
-            current_lines = []
-            continue
-        if current_header is not None:
-            current_lines.append(line)
-
-    if current_header is not None:
-        sections[current_header] = "\n".join(current_lines).strip()
-    return sections
-
-
-def validate_body(body: str, template_path: Path) -> list[str]:
-    errors: list[str] = []
-
-    placeholders = sorted(set(PLACEHOLDER_RE.findall(body)))
-    if placeholders:
-        errors.append(
-            "PR body contains unresolved template placeholders: " + ", ".join(placeholders)
-        )
-
-    sections = extract_sections(body)
-    required_headers = load_required_headers(template_path)
-    for header in required_headers:
-        if header not in sections:
-            errors.append(f"Missing required section header: {header}")
-            continue
-        if not sections[header]:
-            errors.append(f"Section is empty: {header}")
-
-    linked_issue = sections.get("## Linked Issue", "")
-    if linked_issue and not re.search(r"(?im)\bcloses\s+#\d+\b", linked_issue):
-        errors.append("Linked Issue section must contain a `Closes #<issue>` reference.")
-
-    verification = sections.get("## Verification", "")
-    for prefix in REQUIRED_VERIFICATION_PREFIXES:
-        if verification and prefix not in verification:
-            errors.append(f"Verification section is missing required line prefix: {prefix}")
-
-    return errors
-
-
-def main() -> int:
-    args = parse_args()
-    repo_root = Path(__file__).resolve().parents[1]
-    template_path = args.template or repo_root / "skills" / "ora-et-labora" / "assets" / "templates" / "pr.md"
-    body = load_body(args)
-    errors = validate_body(body, template_path)
-    if errors:
-        for error in errors:
-            print(f"ERROR: {error}", file=sys.stderr)
-        return 1
-
-    print("PR body matches the Ora et Labora template contract.")
-    return 0
+SPEC = importlib.util.spec_from_file_location("ora_validate_pr_body", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC is not None and SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(MODULE.main())

--- a/skills/ora-et-labora/SKILL.md
+++ b/skills/ora-et-labora/SKILL.md
@@ -219,8 +219,9 @@ Scripts live under `scripts/`:
 - `render_template.py`: render markdown templates with strict placeholder replacement.
 - `create_issue_from_template.py`: render an issue template and create the GitHub issue from the body file.
 - `create_pr_from_template.py`: render a PR template and create the GitHub PR from the body file.
+- `validate_pr_body.py`: validate a PR body against the Ora et Labora PR template contract.
 - `init_issue_workspace.py`: initialize `00_brainstorm.md`, `CURRENT.md`, and task log.
-- `bootstrap_repo_templates.py`: copy GitHub templates, blueprint docs, and workflow examples into a target repo.
+- `bootstrap_repo_templates.py`: copy GitHub templates, blueprint docs, the standalone PR-body workflow, and workflow examples into a target repo.
 - `bootstrap_repo_templates.py --visibility <profile>`: also writes the profile-aware artifact policy into `.gitignore`.
 - `collect_playwright_artifacts.py`: collect browser verification artifacts into `.project/logs/playwright/<module-id>/<run-id>/`.
 

--- a/skills/ora-et-labora/assets/bootstrap/.github/workflows/validate-pr-body.yml
+++ b/skills/ora-et-labora/assets/bootstrap/.github/workflows/validate-pr-body.yml
@@ -1,0 +1,20 @@
+name: Validate PR Body
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+
+jobs:
+  validate-pr-body:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+        run: python scripts/validate_pr_body.py --body "$PR_BODY"

--- a/skills/ora-et-labora/scripts/bootstrap_repo_templates.py
+++ b/skills/ora-et-labora/scripts/bootstrap_repo_templates.py
@@ -76,6 +76,13 @@ def copy_tree(src_root: Path, dst_root: Path, force: bool) -> None:
         shutil.copyfile(src, dst)
 
 
+def copy_file(src: Path, dst: Path, force: bool) -> None:
+    if dst.exists() and not force:
+        raise SystemExit(f"Refusing to overwrite existing file without --force: {dst}")
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
+
+
 def artifact_policy_block(visibility: str) -> str:
     lines = [BEGIN_MARKER, f"# Visibility profile: {visibility}"]
     lines.extend(GITIGNORE_PROFILES[visibility])
@@ -110,6 +117,11 @@ def main() -> int:
     skill_root = Path(__file__).resolve().parents[1]
     bootstrap_root = skill_root / "assets" / "bootstrap"
     copy_tree(bootstrap_root, args.repo_root, args.force)
+    copy_file(
+        skill_root / "scripts" / "validate_pr_body.py",
+        args.repo_root / "scripts" / "validate_pr_body.py",
+        args.force,
+    )
     if not args.skip_gitignore:
         upsert_gitignore_policy(args.repo_root, args.visibility)
     return 0

--- a/skills/ora-et-labora/scripts/validate_pr_body.py
+++ b/skills/ora-et-labora/scripts/validate_pr_body.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Validate a PR body against the Ora et Labora PR template contract."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+PLACEHOLDER_RE = re.compile(r"\{\{[^}]+\}\}")
+REQUIRED_VERIFICATION_PREFIXES = (
+    "- Local:",
+    "- Browser:",
+    "- Browser evidence:",
+    "- CI:",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--body-file", type=Path)
+    group.add_argument("--body")
+    parser.add_argument("--template", type=Path)
+    return parser.parse_args()
+
+
+def load_body(args: argparse.Namespace) -> str:
+    if args.body_file is not None:
+        return args.body_file.read_text()
+    return args.body
+
+
+def load_required_headers(template_path: Path) -> list[str]:
+    return [line.strip() for line in template_path.read_text().splitlines() if line.startswith("## ")]
+
+
+def extract_sections(body: str) -> dict[str, str]:
+    sections: dict[str, str] = {}
+    current_header: Optional[str] = None
+    current_lines: list[str] = []
+
+    for line in body.splitlines():
+        if line.startswith("## "):
+            if current_header is not None:
+                sections[current_header] = "\n".join(current_lines).strip()
+            current_header = line.strip()
+            current_lines = []
+            continue
+        if current_header is not None:
+            current_lines.append(line)
+
+    if current_header is not None:
+        sections[current_header] = "\n".join(current_lines).strip()
+    return sections
+
+
+def validate_body(body: str, template_path: Path) -> list[str]:
+    errors: list[str] = []
+
+    placeholders = sorted(set(PLACEHOLDER_RE.findall(body)))
+    if placeholders:
+        errors.append(
+            "PR body contains unresolved template placeholders: " + ", ".join(placeholders)
+        )
+
+    sections = extract_sections(body)
+    required_headers = load_required_headers(template_path)
+    for header in required_headers:
+        if header not in sections:
+            errors.append(f"Missing required section header: {header}")
+            continue
+        if not sections[header]:
+            errors.append(f"Section is empty: {header}")
+
+    linked_issue = sections.get("## Linked Issue", "")
+    if linked_issue and not re.search(r"(?im)\bcloses\s+#\d+\b", linked_issue):
+        errors.append("Linked Issue section must contain a `Closes #<issue>` reference.")
+
+    verification = sections.get("## Verification", "")
+    for prefix in REQUIRED_VERIFICATION_PREFIXES:
+        if verification and prefix not in verification:
+            errors.append(f"Verification section is missing required line prefix: {prefix}")
+
+    return errors
+
+
+def default_template_path(script_path: Path) -> Path:
+    candidates = [
+        script_path.resolve().parents[1] / "assets" / "templates" / "pr.md",
+        script_path.resolve().parents[1] / ".github" / "PULL_REQUEST_TEMPLATE.md",
+        script_path.resolve().parents[2] / ".github" / "PULL_REQUEST_TEMPLATE.md",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(
+        "Could not locate a PR template. Pass --template explicitly or ensure the Ora et Labora PR template is present."
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    template_path = args.template or default_template_path(Path(__file__))
+    body = load_body(args)
+    errors = validate_body(body, template_path)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print("PR body matches the Ora et Labora template contract.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/repo-bootstrap/SKILL.md
+++ b/skills/repo-bootstrap/SKILL.md
@@ -55,6 +55,8 @@ Do not use this skill when:
 | Feature issue template | `.github/ISSUE_TEMPLATE/feature_request.md` |
 | Issue template config | `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false` |
 | PR template | `.github/PULL_REQUEST_TEMPLATE.md` with a `Linked Issue` / `Closes #` section |
+| PR body validation workflow | `.github/workflows/validate-pr-body.yml` |
+| PR body validator script | `scripts/validate_pr_body.py` |
 | CI placeholder | `.github/workflows/ci.yml.example` |
 | Release placeholder | `.github/workflows/release.yml.example` |
 | Workflow blueprint | `.project/blueprint/00_workflow.md` |
@@ -105,6 +107,7 @@ Private/internal profile rule: `.project/` may be versioned, but raw browser art
    - Pass `--visibility <profile>` so `.gitignore` receives the right artifact policy.
    - Use `--force` only when overwrite is explicitly intended.
 4. Adapt placeholders.
+   - Keep the standalone PR-body validation workflow active unless the repo already has an equivalent stronger gate.
    - Replace example CI commands with project-specific commands.
    - Replace release placeholders with real release checks when known.
    - Do not leave misleading CI or release placeholders that appear production-ready.

--- a/tests/test_bootstrap_repo_templates.py
+++ b/tests/test_bootstrap_repo_templates.py
@@ -26,16 +26,69 @@ class BootstrapRepoTemplatesTests(unittest.TestCase):
 
             self.assertTrue((repo_root / ".github" / "PULL_REQUEST_TEMPLATE.md").exists())
             self.assertTrue((repo_root / ".github" / "ISSUE_TEMPLATE" / "config.yml").exists())
+            self.assertTrue((repo_root / ".github" / "workflows" / "validate-pr-body.yml").exists())
             self.assertTrue((repo_root / ".project" / "blueprint" / "00_workflow.md").exists())
+            self.assertTrue((repo_root / "scripts" / "validate_pr_body.py").exists())
             pr_template = (repo_root / ".github" / "PULL_REQUEST_TEMPLATE.md").read_text()
             issue_config = (repo_root / ".github" / "ISSUE_TEMPLATE" / "config.yml").read_text()
+            pr_workflow = (repo_root / ".github" / "workflows" / "validate-pr-body.yml").read_text()
             self.assertIn("## Linked Issue", pr_template)
             self.assertIn("Closes #", pr_template)
             self.assertIn("blank_issues_enabled: false", issue_config)
+            self.assertIn("python scripts/validate_pr_body.py", pr_workflow)
             gitignore = (repo_root / ".gitignore").read_text()
             self.assertIn("Visibility profile: private", gitignore)
             self.assertIn(".project/worktrees/", gitignore)
             self.assertNotIn("\n.project/\n", f"\n{gitignore}")
+
+            body = repo_root / "body.md"
+            body.write_text(
+                """## Summary
+
+- Bootstrapped smoke test.
+
+## Why
+
+Ensure the copied validator runs in a target repo.
+
+## Linked Issue
+
+Closes #1
+
+## Verification
+
+- Local: smoke
+- Browser: not applicable
+- Browser evidence: not applicable
+- CI: pending
+
+## Auto-Merge Eligibility
+
+- Not applicable.
+
+## Blueprint Updates
+
+None.
+
+## Risks / Rollback
+
+Revert the bootstrap if needed.
+
+## Follow-ups
+
+- None.
+"""
+            )
+            subprocess.run(
+                [
+                    "python",
+                    str(repo_root / "scripts" / "validate_pr_body.py"),
+                    "--body-file",
+                    str(body),
+                ],
+                check=True,
+                cwd=repo_root,
+            )
 
     def test_public_visibility_keeps_project_state_local(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_template_enforcement_policy.py
+++ b/tests/test_template_enforcement_policy.py
@@ -34,7 +34,11 @@ class TemplateEnforcementPolicyTests(unittest.TestCase):
     def test_validate_workflow_runs_pr_body_gate(self) -> None:
         workflow = (REPO_ROOT / ".github" / "workflows" / "validate.yml").read_text()
         self.assertIn("Validate PR body", workflow)
-        self.assertIn("scripts/validate_pr_body.py", workflow)
+        self.assertIn("skills/ora-et-labora/scripts/validate_pr_body.py", workflow)
+
+    def test_skill_contains_pr_body_validator(self) -> None:
+        validator = (REPO_ROOT / "skills" / "ora-et-labora" / "scripts" / "validate_pr_body.py")
+        self.assertTrue(validator.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_pr_body.py
+++ b/tests/test_validate_pr_body.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-SCRIPT = REPO_ROOT / "scripts" / "validate_pr_body.py"
+SCRIPT = REPO_ROOT / "skills" / "ora-et-labora" / "scripts" / "validate_pr_body.py"
 SPEC = importlib.util.spec_from_file_location("validate_pr_body", SCRIPT)
 MODULE = importlib.util.module_from_spec(SPEC)
 assert SPEC is not None and SPEC.loader is not None


### PR DESCRIPTION
## Summary

- Moves the PR body validator into the shipped `ora-et-labora` skill so installed skills carry the logic.
- Makes bootstrap copy the validator into target repos and adds a standalone `validate-pr-body.yml` workflow asset.
- Adjusts tests and repo docs so the bootstrap payload, installed skill, and suite repo all enforce the same PR body contract.

## Why

The previous PR added PR-body validation for the suite repo itself, but the validator lived only at repo root. That meant installed skills did not contain it, and bootstrapped repos did not inherit the enforcement automatically. This closes that propagation gap.

## Linked Issue

Closes #10

## Verification

- Local: `python scripts/validate_all.py`; `python skills/ora-et-labora/scripts/validate_pr_body.py --body-file .project/todo/8/pr.md`
- Browser: not applicable; workflow/docs/script-only change.
- Browser evidence: not applicable.
- CI: pending after PR creation.

## Auto-Merge Eligibility

- Agent auto-merge requested: yes, once required checks pass.
- This is an implementation PR targeting `dev`.
- Branch is rebased on `origin/dev`.
- Browser verification is not applicable.
- Branch-local `.project` state is current.

## Blueprint Updates

No blueprint files changed. This is a packaging and bootstrap-propagation fix for the template enforcement already added to the suite.

## Risks / Rollback

Risk: path resolution between skill-source usage and copied-into-repo usage could drift again if future template locations change.

Rollback: revert this PR to return to the repo-root-only validator model.

## Follow-ups

- After merge, sync installed local skills again so the shipped validator is present under `~/.codex/skills/ora-et-labora/scripts/`.
- If needed later, fold the standalone PR-body workflow into project-specific CI after bootstrap, but keep an equivalent gate in place.
