### PR TITLE
Release dev to main: workflow enforcement hardening

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,5 +23,10 @@ jobs:
           mkdir -p "$HOME/.codex/skills/.system"
           rm -rf "$HOME/.codex/skills/.system/skill-creator"
           cp -R /tmp/openai-skills/skills/.system/skill-creator "$HOME/.codex/skills/.system/skill-creator"
+      - name: Validate PR body
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+        run: python scripts/validate_pr_body.py --body "$PR_BODY"
       - name: Validate suite
         run: python scripts/validate_all.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,6 +27,7 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           PR_BODY: ${{ github.event.pull_request.body || '' }}
-        run: python skills/ora-et-labora/scripts/validate_pr_body.py --body "$PR_BODY"
+          BASE_BRANCH: ${{ github.base_ref || '' }}
+        run: python skills/ora-et-labora/scripts/validate_pr_body.py --body "$PR_BODY" --base-branch "$BASE_BRANCH"
       - name: Validate suite
         run: python scripts/validate_all.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,6 +27,6 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           PR_BODY: ${{ github.event.pull_request.body || '' }}
-        run: python scripts/validate_pr_body.py --body "$PR_BODY"
+        run: python skills/ora-et-labora/scripts/validate_pr_body.py --body "$PR_BODY"
       - name: Validate suite
         run: python scripts/validate_all.py

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 .DS_Store
 .venv/
+.project/worktrees/

--- a/.project/logs/10.md
+++ b/.project/logs/10.md
@@ -1,0 +1,5 @@
+# Task Log: 10
+
+- 2026-04-24 | state:init | branch:feat/10-bootstrap-pr-body-validation | issue:#10 | note:Workspace initialized.
+- 2026-04-24 | verify:local-pass | command:`python scripts/validate_all.py` | note:21 tests passed and all skills validated after moving the PR validator into the shipped skill payload.
+- 2026-04-24 | verify:bootstrap-smoke-pass | command:`python scripts/validate_pr_body.py --body-file <bootstrapped-body>` | note:Bootstrapped repos receive a runnable validator plus standalone PR-body workflow asset.

--- a/.project/logs/13.md
+++ b/.project/logs/13.md
@@ -1,0 +1,5 @@
+# Task Log: 13
+
+- 2026-04-24 | state:init | branch:feat/13-release-pr-validation | issue:#13 | note:Workspace initialized.
+- 2026-04-24 | verify:local-pass | command:`python scripts/validate_all.py` | note:23 tests passed and all skills validated after adding release-aware PR validation.
+- 2026-04-24 | verify:release-contract-pass | command:`python skills/ora-et-labora/scripts/validate_pr_body.py --body-file /tmp/ora-et-labora-release-2026-04-24.md --base-branch main` | note:Current release PR body shape now passes validation under release mode.

--- a/.project/logs/4-agent-auto-merge-policy.md
+++ b/.project/logs/4-agent-auto-merge-policy.md
@@ -3,3 +3,4 @@
 - 2026-04-21 | state:init | created issue #4 and worktree branch `feat/4-agent-auto-merge-policy`
 - 2026-04-21 | verify:fail | added policy tests first; they failed because auto-merge guidance/templates were absent
 - 2026-04-21 | verify:pass | added auto-merge policy to skills/templates and `python scripts/validate_all.py` passed
+- 2026-04-21 | pr:opened | opened PR #5 targeting `dev` with `Closes #4`

--- a/.project/logs/4-agent-auto-merge-policy.md
+++ b/.project/logs/4-agent-auto-merge-policy.md
@@ -4,3 +4,4 @@
 - 2026-04-21 | verify:fail | added policy tests first; they failed because auto-merge guidance/templates were absent
 - 2026-04-21 | verify:pass | added auto-merge policy to skills/templates and `python scripts/validate_all.py` passed
 - 2026-04-21 | pr:opened | opened PR #5 targeting `dev` with `Closes #4`
+- 2026-04-21 | verify:pass | GitHub PR #5 `validate` check passed; PR is clean and eligible for auto-merge after final state update

--- a/.project/logs/4-agent-auto-merge-policy.md
+++ b/.project/logs/4-agent-auto-merge-policy.md
@@ -1,0 +1,5 @@
+# Agent Auto-Merge Policy Log
+
+- 2026-04-21 | state:init | created issue #4 and worktree branch `feat/4-agent-auto-merge-policy`
+- 2026-04-21 | verify:fail | added policy tests first; they failed because auto-merge guidance/templates were absent
+- 2026-04-21 | verify:pass | added auto-merge policy to skills/templates and `python scripts/validate_all.py` passed

--- a/.project/logs/6-template-enforcement.md
+++ b/.project/logs/6-template-enforcement.md
@@ -3,3 +3,4 @@
 - 2026-04-24 | state:init | created issue #6 and worktree branch `feat/6-template-enforcement`
 - 2026-04-24 | verify:pass | added wrapper scripts, issue-template config, stronger skill wording, and enforcement tests; `python scripts/validate_all.py` passed
 - 2026-04-24 | pr:opened | opened PR #7 targeting `dev` using `create_pr_from_template.py`; PR body comes from the suite template
+- 2026-04-24 | pr:ready | PR #7 is rebased, issue-linked, locally verified, and waiting on current CI; auto-merge will be enabled if the check passes

--- a/.project/logs/6-template-enforcement.md
+++ b/.project/logs/6-template-enforcement.md
@@ -2,3 +2,4 @@
 
 - 2026-04-24 | state:init | created issue #6 and worktree branch `feat/6-template-enforcement`
 - 2026-04-24 | verify:pass | added wrapper scripts, issue-template config, stronger skill wording, and enforcement tests; `python scripts/validate_all.py` passed
+- 2026-04-24 | pr:opened | opened PR #7 targeting `dev` using `create_pr_from_template.py`; PR body comes from the suite template

--- a/.project/logs/6-template-enforcement.md
+++ b/.project/logs/6-template-enforcement.md
@@ -1,0 +1,4 @@
+# Template Enforcement Hardening Log
+
+- 2026-04-24 | state:init | created issue #6 and worktree branch `feat/6-template-enforcement`
+- 2026-04-24 | verify:pass | added wrapper scripts, issue-template config, stronger skill wording, and enforcement tests; `python scripts/validate_all.py` passed

--- a/.project/logs/8.md
+++ b/.project/logs/8.md
@@ -1,0 +1,5 @@
+# Task Log: 8
+
+- 2026-04-24 | state:init | branch:feat/8-pr-body-validation | issue:#8 | note:Workspace initialized.
+- 2026-04-24 | verify:local-pass | command:`python scripts/validate_all.py` | note:20 tests passed and all skills validated after adding the PR body gate.
+- 2026-04-24 | verify:contract-pass | command:`python scripts/validate_pr_body.py --body-file .project/todo/6-template-enforcement/pr.md` | note:Validator accepts the canonical rendered PR structure.

--- a/.project/todo/10/00_brainstorm.md
+++ b/.project/todo/10/00_brainstorm.md
@@ -1,0 +1,41 @@
+# Propagate PR body validation through bootstrap assets: Brainstorm
+
+- Date: 2026-04-24
+- Issue: [#10](https://github.com/emmepra/ora-et-labora/issues/10)
+- Kind: feature
+- Module: 10
+
+## Problem
+
+- 
+
+## Desired Outcome
+
+- 
+
+## Constraints
+
+- 
+
+## Blueprint Fit Check
+
+- Relevant blueprint docs:
+- Feasibility:
+- Conflicts or missing decisions:
+
+## Options Considered
+
+- Option A:
+- Option B:
+
+## Chosen Direction
+
+- 
+
+## Risks / Unknowns
+
+- 
+
+## Acceptance Checks
+
+- 

--- a/.project/todo/10/CURRENT.md
+++ b/.project/todo/10/CURRENT.md
@@ -1,0 +1,14 @@
+# Current State
+
+- Issue: [#10](https://github.com/emmepra/ora-et-labora/issues/10)
+- Title: Propagate PR body validation through bootstrap assets
+- Kind: feature
+- Module: 10
+- Branch: feat/10-bootstrap-pr-body-validation
+- Status: implementation complete; ready to open PR
+- PR: pending
+- Last verification: `python scripts/validate_all.py` passed; skill-owned validator and bootstrapped-copy smoke checks passed
+- Browser evidence: not applicable
+- Next step: commit, push, and open the PR to `dev`; then enable auto-merge once required checks are pending/passing
+- Blockers: none
+- Files touched: `.github/workflows/validate.yml`, `scripts/validate_pr_body.py`, `skills/ora-et-labora/SKILL.md`, `skills/ora-et-labora/scripts/bootstrap_repo_templates.py`, `skills/ora-et-labora/scripts/validate_pr_body.py`, `skills/ora-et-labora/assets/bootstrap/.github/workflows/validate-pr-body.yml`, `skills/repo-bootstrap/SKILL.md`, `tests/test_bootstrap_repo_templates.py`, `tests/test_template_enforcement_policy.py`, `tests/test_validate_pr_body.py`

--- a/.project/todo/10/pr.md
+++ b/.project/todo/10/pr.md
@@ -1,0 +1,43 @@
+## Summary
+
+- Moves the PR body validator into the shipped `ora-et-labora` skill so installed skills carry the logic.
+- Makes bootstrap copy the validator into target repos and adds a standalone `validate-pr-body.yml` workflow asset.
+- Adjusts tests and repo docs so the bootstrap payload, installed skill, and suite repo all enforce the same PR body contract.
+
+## Why
+
+The previous PR added PR-body validation for the suite repo itself, but the validator lived only at repo root. That meant installed skills did not contain it, and bootstrapped repos did not inherit the enforcement automatically. This closes that propagation gap.
+
+## Linked Issue
+
+Closes #10
+
+## Verification
+
+- Local: `python scripts/validate_all.py`; `python skills/ora-et-labora/scripts/validate_pr_body.py --body-file .project/todo/8/pr.md`
+- Browser: not applicable; workflow/docs/script-only change.
+- Browser evidence: not applicable.
+- CI: pending after PR creation.
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: yes, once required checks pass.
+- This is an implementation PR targeting `dev`.
+- Branch is rebased on `origin/dev`.
+- Browser verification is not applicable.
+- Branch-local `.project` state is current.
+
+## Blueprint Updates
+
+No blueprint files changed. This is a packaging and bootstrap-propagation fix for the template enforcement already added to the suite.
+
+## Risks / Rollback
+
+Risk: path resolution between skill-source usage and copied-into-repo usage could drift again if future template locations change.
+
+Rollback: revert this PR to return to the repo-root-only validator model.
+
+## Follow-ups
+
+- After merge, sync installed local skills again so the shipped validator is present under `~/.codex/skills/ora-et-labora/scripts/`.
+- If needed later, fold the standalone PR-body workflow into project-specific CI after bootstrap, but keep an equivalent gate in place.

--- a/.project/todo/13/00_brainstorm.md
+++ b/.project/todo/13/00_brainstorm.md
@@ -1,0 +1,41 @@
+# Support release PR bodies in validation gate: Brainstorm
+
+- Date: 2026-04-24
+- Issue: [#13](https://github.com/emmepra/ora-et-labora/issues/13)
+- Kind: feature
+- Module: 13
+
+## Problem
+
+- 
+
+## Desired Outcome
+
+- 
+
+## Constraints
+
+- 
+
+## Blueprint Fit Check
+
+- Relevant blueprint docs:
+- Feasibility:
+- Conflicts or missing decisions:
+
+## Options Considered
+
+- Option A:
+- Option B:
+
+## Chosen Direction
+
+- 
+
+## Risks / Unknowns
+
+- 
+
+## Acceptance Checks
+
+- 

--- a/.project/todo/13/CURRENT.md
+++ b/.project/todo/13/CURRENT.md
@@ -1,0 +1,14 @@
+# Current State
+
+- Issue: [#13](https://github.com/emmepra/ora-et-labora/issues/13)
+- Title: Support release PR bodies in validation gate
+- Kind: feature
+- Module: 13
+- Branch: feat/13-release-pr-validation
+- Status: implementation complete; ready to open PR
+- PR: pending
+- Last verification: `python scripts/validate_all.py` passed; `python skills/ora-et-labora/scripts/validate_pr_body.py --body-file /tmp/ora-et-labora-release-2026-04-24.md --base-branch main` passed
+- Browser evidence: not applicable
+- Next step: commit, push, and open the PR to `dev`; then enable auto-merge once required checks are pending/passing
+- Blockers: none
+- Files touched: `.github/workflows/validate.yml`, `README.md`, `skills/ora-et-labora/assets/bootstrap/.github/workflows/validate-pr-body.yml`, `skills/ora-et-labora/scripts/validate_pr_body.py`, `skills/release-train/SKILL.md`, `tests/test_bootstrap_repo_templates.py`, `tests/test_template_enforcement_policy.py`, `tests/test_validate_pr_body.py`

--- a/.project/todo/13/pr.md
+++ b/.project/todo/13/pr.md
@@ -1,0 +1,43 @@
+## Summary
+
+- Makes the PR-body validator distinguish implementation PRs from release PRs.
+- Passes the PR base branch into both repo-local and bootstrapped validation workflows.
+- Adds release-path tests and documents that release PRs keep the release template instead of being forced into the implementation PR shape.
+
+## Why
+
+The active `dev` -> `main` release PR failed immediately because the validator enforced only the implementation PR template. Release PRs use a different template by design, so the gate needed to become release-aware without weakening implementation PR checks.
+
+## Linked Issue
+
+Closes #13
+
+## Verification
+
+- Local: `python scripts/validate_all.py`; `python skills/ora-et-labora/scripts/validate_pr_body.py --body-file /tmp/ora-et-labora-release-2026-04-24.md --base-branch main`
+- Browser: not applicable; workflow/docs/script-only change.
+- Browser evidence: not applicable.
+- CI: pending after PR creation.
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: yes, once required checks pass.
+- This is an implementation PR targeting `dev`.
+- Branch is rebased on `origin/dev`.
+- Browser verification is not applicable.
+- Branch-local `.project` state is current.
+
+## Blueprint Updates
+
+No blueprint files changed. This fixes a mismatch between the stable release flow and the PR-body enforcement gate.
+
+## Risks / Rollback
+
+Risk: if mode selection regresses, release PRs could fail again or implementation PRs could accidentally become too permissive.
+
+Rollback: revert this PR to restore the previous validator behavior, then manually relax the release gate until a corrected follow-up lands.
+
+## Follow-ups
+
+- After merge, recheck release PR #12 and merge it once green.
+- After the release lands on `main`, resync installed local skills from stable.

--- a/.project/todo/4-agent-auto-merge-policy/00_brainstorm.md
+++ b/.project/todo/4-agent-auto-merge-policy/00_brainstorm.md
@@ -1,0 +1,28 @@
+# Agent Auto-Merge Policy
+
+## Problem
+
+Ora et Labora has PR-first integration and release gates, but it does not explicitly define when agents may auto-merge PRs.
+
+## Challenge Collection
+
+- Auto-merge is useful for implementation PRs into `dev` when checks are green or pending under GitHub auto-merge.
+- Auto-merge is risky for release PRs into `main` because `main` is stable and should require explicit user approval.
+- Agents need a deterministic eligibility checklist to avoid merging stale, unreviewed, or issue-unlinked PRs.
+- The policy must distinguish `gh pr merge --auto` from immediate merge after checks are already green.
+- State logging should record when auto-merge is enabled or blocked.
+
+## Decision
+
+Allow agent auto-merge only for implementation PRs targeting `dev` when all gates are satisfied. Require explicit user approval for release PRs targeting `main`.
+
+## Blueprint Fit
+
+- Fits the existing PR-first model.
+- Preserves `main` as stable.
+- Extends durable workflow knowledge, so the skill files and templates should be updated.
+
+## Verification Plan
+
+- Add tests requiring the auto-merge policy in the relevant skill files and PR templates.
+- Run `python scripts/validate_all.py`.

--- a/.project/todo/4-agent-auto-merge-policy/CURRENT.md
+++ b/.project/todo/4-agent-auto-merge-policy/CURRENT.md
@@ -1,0 +1,29 @@
+# Current State - Agent Auto-Merge Policy
+
+## Issue
+
+https://github.com/emmepra/ora-et-labora/issues/4
+
+## Branch
+
+`feat/4-agent-auto-merge-policy`
+
+## Worktree
+
+`.project/worktrees/feat-4-agent-auto-merge-policy`
+
+## Status
+
+Implementation complete; PR pending.
+
+## Latest Verification
+
+`python scripts/validate_all.py` passed.
+
+## Next Step
+
+Commit, push, and open PR to `dev`.
+
+## Blockers
+
+None.

--- a/.project/todo/4-agent-auto-merge-policy/CURRENT.md
+++ b/.project/todo/4-agent-auto-merge-policy/CURRENT.md
@@ -14,7 +14,11 @@ https://github.com/emmepra/ora-et-labora/issues/4
 
 ## Status
 
-Implementation complete; PR pending.
+Implementation complete; PR open.
+
+## PR
+
+https://github.com/emmepra/ora-et-labora/pull/5
 
 ## Latest Verification
 
@@ -22,7 +26,7 @@ Implementation complete; PR pending.
 
 ## Next Step
 
-Commit, push, and open PR to `dev`.
+Update PR body, wait for CI, and enable/complete auto-merge if gates pass.
 
 ## Blockers
 

--- a/.project/todo/4-agent-auto-merge-policy/CURRENT.md
+++ b/.project/todo/4-agent-auto-merge-policy/CURRENT.md
@@ -22,11 +22,11 @@ https://github.com/emmepra/ora-et-labora/pull/5
 
 ## Latest Verification
 
-`python scripts/validate_all.py` passed.
+`python scripts/validate_all.py` passed locally. GitHub `validate` passed on PR #5 before final state update.
 
 ## Next Step
 
-Update PR body, wait for CI, and enable/complete auto-merge if gates pass.
+Enable GitHub auto-merge on PR #5 and confirm merge/issue closure.
 
 ## Blockers
 

--- a/.project/todo/4-agent-auto-merge-policy/pr.md
+++ b/.project/todo/4-agent-auto-merge-policy/pr.md
@@ -22,8 +22,14 @@ Closes #4
 
 ## Auto-Merge Eligibility
 
-- Agent auto-merge requested: no for this PR; review before merging.
-- This PR defines the policy and should not be used as the first unattended auto-merge test.
+- Agent auto-merge requested: yes, after required checks pass.
+- Target is `dev`.
+- PR is not a release PR into `main`.
+- Branch was rebased on `origin/dev` before push.
+- PR body includes `Closes #4`.
+- Local verification passed with `python scripts/validate_all.py`.
+- Browser verification is not applicable for this docs/process/template-only change.
+- Branch-local `.project` state is current.
 
 ## Blueprint Updates
 

--- a/.project/todo/4-agent-auto-merge-policy/pr.md
+++ b/.project/todo/4-agent-auto-merge-policy/pr.md
@@ -1,0 +1,40 @@
+## Summary
+
+- Adds the safe agent auto-merge policy for implementation PRs into `dev`.
+- Keeps release PRs into `main` gated by explicit user approval.
+- Updates PR templates with an auto-merge eligibility section.
+- Adds tests to keep the policy present in skills and templates.
+
+## Why
+
+Agents can technically merge PRs when permissions allow it, but Ora et Labora needed a durable policy for when that is safe. This prevents accidental stable releases, stale-branch merges, issue-unlinked merges, and merges with unresolved review or verification gaps.
+
+## Linked Issue
+
+Closes #4
+
+## Verification
+
+- Local: `python scripts/validate_all.py`
+- Browser: not applicable; process/docs/template-only change.
+- Browser evidence: not applicable.
+- CI: pending after PR creation.
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: no for this PR; review before merging.
+- This PR defines the policy and should not be used as the first unattended auto-merge test.
+
+## Blueprint Updates
+
+No `.project/blueprint/` files changed. The durable workflow policy is encoded directly in the skill files and templates.
+
+## Risks / Rollback
+
+Risk is procedural: agents may over-apply auto-merge unless the gates are read carefully. The policy explicitly blocks release PR auto-merge to `main` without explicit approval.
+
+Rollback: revert this PR if the auto-merge policy proves too permissive.
+
+## Follow-ups
+
+- After merge, sync installed local skills and optionally promote `dev` to `main`.

--- a/.project/todo/6-template-enforcement/00_brainstorm.md
+++ b/.project/todo/6-template-enforcement/00_brainstorm.md
@@ -1,0 +1,21 @@
+# Template Enforcement Hardening
+
+## Problem
+
+Ora et Labora recommends issue/PR templates, but the creation path is still easy to bypass.
+
+## Decision
+
+Harden template usage in four places:
+
+- disable blank issues in bootstrapped repos
+- add dedicated helper scripts for issue and PR creation from templates
+- tighten skill wording so wrapper/body-file usage is the required path
+- add tests that protect these rules
+
+## Acceptance Checks
+
+- issue template config exists and disables blank issues
+- helper scripts render bodies and drive `gh ... --body-file`
+- skill docs point to the wrappers as the standard path
+- validation passes

--- a/.project/todo/6-template-enforcement/CURRENT.md
+++ b/.project/todo/6-template-enforcement/CURRENT.md
@@ -1,0 +1,29 @@
+# Current State - Template Enforcement Hardening
+
+## Issue
+
+https://github.com/emmepra/ora-et-labora/issues/6
+
+## Branch
+
+`feat/6-template-enforcement`
+
+## Worktree
+
+`.project/worktrees/feat-6-template-enforcement`
+
+## Status
+
+Implementation complete; PR pending.
+
+## Latest Verification
+
+`python scripts/validate_all.py` passed.
+
+## Next Step
+
+Commit, push, and open PR to `dev` using the PR wrapper script.
+
+## Blockers
+
+None.

--- a/.project/todo/6-template-enforcement/CURRENT.md
+++ b/.project/todo/6-template-enforcement/CURRENT.md
@@ -22,11 +22,11 @@ https://github.com/emmepra/ora-et-labora/pull/7
 
 ## Latest Verification
 
-`python scripts/validate_all.py` passed.
+`python scripts/validate_all.py` passed locally. GitHub `validate` is currently running on PR #7.
 
 ## Next Step
 
-Wait for CI and enable auto-merge if the gates pass.
+Auto-merge requested once the current `validate` check passes.
 
 ## Blockers
 

--- a/.project/todo/6-template-enforcement/CURRENT.md
+++ b/.project/todo/6-template-enforcement/CURRENT.md
@@ -14,7 +14,11 @@ https://github.com/emmepra/ora-et-labora/issues/6
 
 ## Status
 
-Implementation complete; PR pending.
+Implementation complete; PR open.
+
+## PR
+
+https://github.com/emmepra/ora-et-labora/pull/7
 
 ## Latest Verification
 
@@ -22,7 +26,7 @@ Implementation complete; PR pending.
 
 ## Next Step
 
-Commit, push, and open PR to `dev` using the PR wrapper script.
+Wait for CI and enable auto-merge if the gates pass.
 
 ## Blockers
 

--- a/.project/todo/6-template-enforcement/pr.md
+++ b/.project/todo/6-template-enforcement/pr.md
@@ -1,0 +1,43 @@
+## Summary
+
+- Adds dedicated issue and PR creation wrapper scripts.
+- Adds GitHub issue template config that disables blank issues in bootstrapped repos.
+- Tightens skill wording and tests so template usage is harder to bypass.
+
+## Why
+
+Template usage was recommended but still easy to bypass with raw gh commands. This change makes wrappers the standard path and adds tests that keep the policy in place.
+
+## Linked Issue
+
+Closes #6
+
+## Verification
+
+- Local: `python scripts/validate_all.py`
+- Browser: not applicable; process/docs/script-only change.
+- Browser evidence: not applicable.
+- CI: pending after PR creation.
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: yes, once required checks pass.
+- This is an implementation PR targeting `dev`.
+- Branch is rebased on `origin/dev`.
+- Browser verification is not applicable.
+- Branch-local `.project` state is current.
+
+## Blueprint Updates
+
+No blueprint files changed. This hardens workflow execution rules encoded in the skill suite itself.
+
+## Risks / Rollback
+
+Risk: stricter template usage may require agents to adopt the new wrappers.
+
+Rollback: revert this PR if the wrappers or issue-template config prove too rigid.
+
+## Follow-ups
+
+- After merge, sync installed local skills.
+- Optionally promote `dev` to `main` if you want the stable installer path updated.

--- a/.project/todo/8/00_brainstorm.md
+++ b/.project/todo/8/00_brainstorm.md
@@ -1,0 +1,41 @@
+# Add PR body validation gate: Brainstorm
+
+- Date: 2026-04-24
+- Issue: [#8](https://github.com/emmepra/ora-et-labora/issues/8)
+- Kind: feature
+- Module: 8
+
+## Problem
+
+- 
+
+## Desired Outcome
+
+- 
+
+## Constraints
+
+- 
+
+## Blueprint Fit Check
+
+- Relevant blueprint docs:
+- Feasibility:
+- Conflicts or missing decisions:
+
+## Options Considered
+
+- Option A:
+- Option B:
+
+## Chosen Direction
+
+- 
+
+## Risks / Unknowns
+
+- 
+
+## Acceptance Checks
+
+- 

--- a/.project/todo/8/CURRENT.md
+++ b/.project/todo/8/CURRENT.md
@@ -1,0 +1,14 @@
+# Current State
+
+- Issue: [#8](https://github.com/emmepra/ora-et-labora/issues/8)
+- Title: Add PR body validation gate
+- Kind: feature
+- Module: 8
+- Branch: feat/8-pr-body-validation
+- Status: implementation complete; ready to open PR
+- PR: pending
+- Last verification: `python scripts/validate_all.py` passed; `python scripts/validate_pr_body.py --body-file .project/todo/6-template-enforcement/pr.md` passed
+- Browser evidence: not applicable
+- Next step: commit, push, and open the PR to `dev`; then enable auto-merge once required checks are pending/passing
+- Blockers: none
+- Files touched: `.github/workflows/validate.yml`, `README.md`, `skills/worktree-flow/SKILL.md`, `scripts/validate_pr_body.py`, `tests/test_template_enforcement_policy.py`, `tests/test_validate_pr_body.py`

--- a/.project/todo/8/pr.md
+++ b/.project/todo/8/pr.md
@@ -1,0 +1,43 @@
+## Summary
+
+- Adds a PR body validation script that enforces the Ora et Labora PR template contract.
+- Runs the new gate in GitHub `validate` on every pull request before suite validation.
+- Adds tests for valid PR bodies, missing sections, missing `Closes #` references, and unresolved placeholders.
+
+## Why
+
+The template wrappers and GitHub issue config hardened issue and PR creation, but malformed PR bodies could still slip through if an agent bypassed the standard rendering path. This adds the missing CI-side enforcement so PR template structure becomes a real gate.
+
+## Linked Issue
+
+Closes #8
+
+## Verification
+
+- Local: `python scripts/validate_all.py`; `python scripts/validate_pr_body.py --body-file .project/todo/6-template-enforcement/pr.md`
+- Browser: not applicable; workflow/docs/script-only change.
+- Browser evidence: not applicable.
+- CI: pending after PR creation.
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: yes, once required checks pass.
+- This is an implementation PR targeting `dev`.
+- Branch is rebased on `origin/dev`.
+- Browser verification is not applicable.
+- Branch-local `.project` state is current.
+
+## Blueprint Updates
+
+No blueprint files changed. This extends the template-enforcement workflow already added to the suite by making PR body structure enforceable in CI.
+
+## Risks / Rollback
+
+Risk: the validator could be too strict and reject legitimate PR bodies if the template contract changes without updating the script.
+
+Rollback: revert this PR to remove the CI gate and validator if it blocks valid workflow.
+
+## Follow-ups
+
+- After merge, sync installed local skills.
+- If desired later, add a similar review-time gate for issue bodies, though GitHub issue templates and wrapper usage already cover most of that path.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The suite is built around a simple idea:
 - keep one issue, one branch, one worktree, and one resumable state surface
 - verify using the right modality for the change
 - make implementation PRs close their originating issues on merge
+- allow implementation PR auto-merge only after explicit safety gates
 - treat browser evidence and Docker runtime behavior as first-class operational concerns
 - choose a public/private/internal artifact policy before publishing workflow state
 - integrate into `dev`
@@ -26,7 +27,7 @@ Once the issue is shaped, the skill creates or resumes a branch-local execution 
 
 Implementation then happens inside the worktree, with verification driven by the type of change. Frontend work is not "tested" in the abstract; it is verified in the browser, with Playwright evidence collected into a stable repo-local log path. Docker-backed projects are handled with explicit worktree rules so switching branches does not turn into port collisions and stale containers.
 
-The branch flow is PR-first into `dev`, while stable promotion happens through grouped `dev` to `main` release PRs.
+The branch flow is PR-first into `dev`. Implementation PRs may use agent auto-merge only after branch freshness, verification, CI/review, issue-closure, and state-logging gates are satisfied. Stable promotion happens through grouped `dev` to `main` release PRs, and those release PRs require explicit user approval before merge.
 
 Repo creation and bootstrap are visibility-aware. Private and internal repos can version `.project/` as durable agent memory, while public repos keep `.project/` local by default and publish only sanitized contributor-facing docs and GitHub templates.
 
@@ -67,6 +68,8 @@ Repo creation and bootstrap are visibility-aware. Private and internal repos can
 - Verification is modality-specific.
 - Browser verification requires evidence, not just a claim.
 - Implementation PRs must reference and close their originating issues.
+- Implementation PR auto-merge is allowed only for eligible `dev` PRs.
+- Release PRs into `main` require explicit approval before merge.
 - Docker behavior across worktrees must be explicit.
 - Public repos keep agent-private state local unless explicitly sanitized.
 - `dev` is the integration branch.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The suite includes:
 - issue, PR, release, brainstorm, current-state, and log templates
 - bootstrap assets for `.github/` and `.project/blueprint/`
 - helper scripts for template rendering, issue/PR creation, issue workspace initialization, visibility-aware bootstrap, and Playwright artifact collection
-- a CI gate that rejects malformed PR bodies that do not satisfy the suite PR template contract
+- a CI gate that rejects malformed implementation or release PR bodies that do not satisfy the suite contract
 
 The operating procedure is intentionally inline in the skill files. Extra files are reserved for templates, scripts, bootstrap assets, tests, and examples.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The suite includes:
 - detailed self-contained `SKILL.md` bodies with procedure, red flags, rationalization counters, and completion checklists
 - issue, PR, release, brainstorm, current-state, and log templates
 - bootstrap assets for `.github/` and `.project/blueprint/`
-- helper scripts for template rendering, issue workspace initialization, visibility-aware bootstrap, and Playwright artifact collection
+- helper scripts for template rendering, issue/PR creation, issue workspace initialization, visibility-aware bootstrap, and Playwright artifact collection
 
 The operating procedure is intentionally inline in the skill files. Extra files are reserved for templates, scripts, bootstrap assets, tests, and examples.
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The suite includes:
 - issue, PR, release, brainstorm, current-state, and log templates
 - bootstrap assets for `.github/` and `.project/blueprint/`
 - helper scripts for template rendering, issue/PR creation, issue workspace initialization, visibility-aware bootstrap, and Playwright artifact collection
+- a CI gate that rejects malformed PR bodies that do not satisfy the suite PR template contract
 
 The operating procedure is intentionally inline in the skill files. Extra files are reserved for templates, scripts, bootstrap assets, tests, and examples.
 

--- a/scripts/validate_pr_body.py
+++ b/scripts/validate_pr_body.py
@@ -1,107 +1,24 @@
 #!/usr/bin/env python3
-"""Validate a PR body against the Ora et Labora PR template contract."""
+"""Convenience wrapper for the skill-owned PR body validator."""
 
 from __future__ import annotations
 
-import argparse
-import re
-import sys
+import importlib.util
 from pathlib import Path
-from typing import Optional
 
 
-PLACEHOLDER_RE = re.compile(r"\{\{[^}]+\}\}")
-REQUIRED_VERIFICATION_PREFIXES = (
-    "- Local:",
-    "- Browser:",
-    "- Browser evidence:",
-    "- CI:",
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "ora-et-labora"
+    / "scripts"
+    / "validate_pr_body.py"
 )
-
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=__doc__)
-    group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--body-file", type=Path)
-    group.add_argument("--body")
-    parser.add_argument("--template", type=Path)
-    return parser.parse_args()
-
-
-def load_body(args: argparse.Namespace) -> str:
-    if args.body_file is not None:
-        return args.body_file.read_text()
-    return args.body
-
-
-def load_required_headers(template_path: Path) -> list[str]:
-    return [line.strip() for line in template_path.read_text().splitlines() if line.startswith("## ")]
-
-
-def extract_sections(body: str) -> dict[str, str]:
-    sections: dict[str, str] = {}
-    current_header: Optional[str] = None
-    current_lines: list[str] = []
-
-    for line in body.splitlines():
-        if line.startswith("## "):
-            if current_header is not None:
-                sections[current_header] = "\n".join(current_lines).strip()
-            current_header = line.strip()
-            current_lines = []
-            continue
-        if current_header is not None:
-            current_lines.append(line)
-
-    if current_header is not None:
-        sections[current_header] = "\n".join(current_lines).strip()
-    return sections
-
-
-def validate_body(body: str, template_path: Path) -> list[str]:
-    errors: list[str] = []
-
-    placeholders = sorted(set(PLACEHOLDER_RE.findall(body)))
-    if placeholders:
-        errors.append(
-            "PR body contains unresolved template placeholders: " + ", ".join(placeholders)
-        )
-
-    sections = extract_sections(body)
-    required_headers = load_required_headers(template_path)
-    for header in required_headers:
-        if header not in sections:
-            errors.append(f"Missing required section header: {header}")
-            continue
-        if not sections[header]:
-            errors.append(f"Section is empty: {header}")
-
-    linked_issue = sections.get("## Linked Issue", "")
-    if linked_issue and not re.search(r"(?im)\bcloses\s+#\d+\b", linked_issue):
-        errors.append("Linked Issue section must contain a `Closes #<issue>` reference.")
-
-    verification = sections.get("## Verification", "")
-    for prefix in REQUIRED_VERIFICATION_PREFIXES:
-        if verification and prefix not in verification:
-            errors.append(f"Verification section is missing required line prefix: {prefix}")
-
-    return errors
-
-
-def main() -> int:
-    args = parse_args()
-    repo_root = Path(__file__).resolve().parents[1]
-    template_path = args.template or repo_root / "skills" / "ora-et-labora" / "assets" / "templates" / "pr.md"
-    body = load_body(args)
-    errors = validate_body(body, template_path)
-    if errors:
-        for error in errors:
-            print(f"ERROR: {error}", file=sys.stderr)
-        return 1
-
-    print("PR body matches the Ora et Labora template contract.")
-    return 0
+SPEC = importlib.util.spec_from_file_location("ora_validate_pr_body", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC is not None and SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(MODULE.main())

--- a/scripts/validate_pr_body.py
+++ b/scripts/validate_pr_body.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Validate a PR body against the Ora et Labora PR template contract."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+PLACEHOLDER_RE = re.compile(r"\{\{[^}]+\}\}")
+REQUIRED_VERIFICATION_PREFIXES = (
+    "- Local:",
+    "- Browser:",
+    "- Browser evidence:",
+    "- CI:",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--body-file", type=Path)
+    group.add_argument("--body")
+    parser.add_argument("--template", type=Path)
+    return parser.parse_args()
+
+
+def load_body(args: argparse.Namespace) -> str:
+    if args.body_file is not None:
+        return args.body_file.read_text()
+    return args.body
+
+
+def load_required_headers(template_path: Path) -> list[str]:
+    return [line.strip() for line in template_path.read_text().splitlines() if line.startswith("## ")]
+
+
+def extract_sections(body: str) -> dict[str, str]:
+    sections: dict[str, str] = {}
+    current_header: Optional[str] = None
+    current_lines: list[str] = []
+
+    for line in body.splitlines():
+        if line.startswith("## "):
+            if current_header is not None:
+                sections[current_header] = "\n".join(current_lines).strip()
+            current_header = line.strip()
+            current_lines = []
+            continue
+        if current_header is not None:
+            current_lines.append(line)
+
+    if current_header is not None:
+        sections[current_header] = "\n".join(current_lines).strip()
+    return sections
+
+
+def validate_body(body: str, template_path: Path) -> list[str]:
+    errors: list[str] = []
+
+    placeholders = sorted(set(PLACEHOLDER_RE.findall(body)))
+    if placeholders:
+        errors.append(
+            "PR body contains unresolved template placeholders: " + ", ".join(placeholders)
+        )
+
+    sections = extract_sections(body)
+    required_headers = load_required_headers(template_path)
+    for header in required_headers:
+        if header not in sections:
+            errors.append(f"Missing required section header: {header}")
+            continue
+        if not sections[header]:
+            errors.append(f"Section is empty: {header}")
+
+    linked_issue = sections.get("## Linked Issue", "")
+    if linked_issue and not re.search(r"(?im)\bcloses\s+#\d+\b", linked_issue):
+        errors.append("Linked Issue section must contain a `Closes #<issue>` reference.")
+
+    verification = sections.get("## Verification", "")
+    for prefix in REQUIRED_VERIFICATION_PREFIXES:
+        if verification and prefix not in verification:
+            errors.append(f"Verification section is missing required line prefix: {prefix}")
+
+    return errors
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    template_path = args.template or repo_root / "skills" / "ora-et-labora" / "assets" / "templates" / "pr.md"
+    body = load_body(args)
+    errors = validate_body(body, template_path)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print("PR body matches the Ora et Labora template contract.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/issue-shaping/SKILL.md
+++ b/skills/issue-shaping/SKILL.md
@@ -49,7 +49,7 @@ Do not use this skill for:
 - clarify the problem and intended outcome before code changes
 - capture constraints, non-goals, risks, unknowns, and acceptance checks
 - produce or update `.project/todo/<module-id>/00_brainstorm.md`
-- draft or refine the GitHub issue body using a template or body file
+- draft or refine the GitHub issue body using the issue wrapper or a rendered body file
 - identify the likely verification modalities early
 - leave a clean handoff for blueprint checking and worktree setup
 
@@ -112,7 +112,9 @@ If the same paragraph appears in all artifacts, the workflow is becoming redunda
 8. Draft or refine the GitHub issue body.
    - Use `issue-bug.md` for bugs.
    - Use `issue-feature.md` for features.
-   - Use a body file with `gh issue create --body-file <file>` when creating the issue.
+   - Standard path: use `../ora-et-labora/scripts/create_issue_from_template.py`.
+   - Minimum fallback: render a body file first, then use `gh issue create --body-file <file>`.
+   - Do not hand-write multi-section issue markdown directly into `gh issue create`.
 
 ## Output Contract
 
@@ -145,7 +147,7 @@ A shaped issue is ready only when:
 - acceptance checks are concrete
 - verification modalities are named
 - any suspected blueprint conflict is visible
-- the issue body is valid markdown rendered from a file or template
+- the issue body is valid markdown rendered through the wrapper script or a rendered template body file
 
 ## Red Flags - Stop Before Coding
 
@@ -208,8 +210,9 @@ Verification plan:
 - `../ora-et-labora/assets/templates/issue-bug.md`
 - `../ora-et-labora/assets/templates/issue-feature.md`
 - `../ora-et-labora/scripts/render_template.py`
+- `../ora-et-labora/scripts/create_issue_from_template.py`
 
-Use templates and rendered body files when producing GitHub issue markdown.
+Use the issue wrapper by default. Raw `gh issue create` is acceptable only when it still uses a rendered body file and the wrapper genuinely does not fit the operation.
 
 ## Handoff
 

--- a/skills/ora-et-labora/SKILL.md
+++ b/skills/ora-et-labora/SKILL.md
@@ -186,8 +186,10 @@ Use templates and body files for complex GitHub markdown.
 
 Use:
 
-- `gh issue create --body-file <file>`
-- `gh pr create --body-file <file>`
+- `create_issue_from_template.py` for issue creation
+- `create_pr_from_template.py` for PR creation
+- `gh issue create --body-file <file>` only as a fallback after rendering a body file
+- `gh pr create --body-file <file>` only as a fallback after rendering a body file
 
 Avoid:
 
@@ -215,6 +217,8 @@ Use these rather than recreating structure from memory.
 Scripts live under `scripts/`:
 
 - `render_template.py`: render markdown templates with strict placeholder replacement.
+- `create_issue_from_template.py`: render an issue template and create the GitHub issue from the body file.
+- `create_pr_from_template.py`: render a PR template and create the GitHub PR from the body file.
 - `init_issue_workspace.py`: initialize `00_brainstorm.md`, `CURRENT.md`, and task log.
 - `bootstrap_repo_templates.py`: copy GitHub templates, blueprint docs, and workflow examples into a target repo.
 - `bootstrap_repo_templates.py --visibility <profile>`: also writes the profile-aware artifact policy into `.gitignore`.
@@ -229,6 +233,7 @@ Prefer scripts for deterministic file layout and template rendering.
 - "I will use one log file for every branch."
 - "I will open a PR to `main` for normal feature work."
 - "I will open the PR without `Closes #<issue>` and close the issue manually later."
+- "I will skip the wrapper script and hand-write the issue or PR body inline."
 - "I will enable auto-merge without checking CI, reviews, branch freshness, and task state."
 - "I will auto-merge the release PR into `main` because checks are green."
 - "I will publish `.project/` in a public repo because it is only process state."

--- a/skills/ora-et-labora/SKILL.md
+++ b/skills/ora-et-labora/SKILL.md
@@ -88,7 +88,9 @@ Do not use this skill as a substitute for the detailed phase skills. If the task
 - Treat Playwright artifacts as required evidence for browser verification, not as disposable temp output.
 - Open implementation PRs into `dev`.
 - Implementation PRs must reference the originating issue with a GitHub closing keyword, such as `Closes #123`, so the issue closes when the PR is merged into the default branch.
+- Implementation PRs into `dev` may use agent auto-merge only after branch freshness, verification, CI/review, issue-closure, and state-logging gates are satisfied.
 - Promote `dev` to `main` through grouped release PRs, not one `main` merge per implementation PR.
+- Release PRs into `main` require explicit user approval before merge; do not enable auto-merge for stable releases by default.
 - Render GitHub issue and PR bodies from files or templates. Do not assemble complex markdown inline in a shell command.
 
 ## Artifact Ownership
@@ -157,7 +159,9 @@ Durable project knowledge includes architecture boundaries, contracts, environme
 - `main` is the stable branch.
 - implementation PRs target `dev`.
 - implementation PRs include a closing issue reference, for example `Closes #123`.
+- implementation PRs may use `gh pr merge --auto` only when all auto-merge gates are satisfied.
 - release PRs promote grouped `dev` changes to `main`.
+- release PRs require explicit user approval before merge, even when checks are green.
 
 ## Docker And Runtime Rules
 
@@ -225,6 +229,8 @@ Prefer scripts for deterministic file layout and template rendering.
 - "I will use one log file for every branch."
 - "I will open a PR to `main` for normal feature work."
 - "I will open the PR without `Closes #<issue>` and close the issue manually later."
+- "I will enable auto-merge without checking CI, reviews, branch freshness, and task state."
+- "I will auto-merge the release PR into `main` because checks are green."
 - "I will publish `.project/` in a public repo because it is only process state."
 - "I will claim frontend verification without browser evidence."
 - "I will paste complex markdown directly into `gh issue create`."

--- a/skills/ora-et-labora/SKILL.md
+++ b/skills/ora-et-labora/SKILL.md
@@ -219,8 +219,9 @@ Scripts live under `scripts/`:
 - `render_template.py`: render markdown templates with strict placeholder replacement.
 - `create_issue_from_template.py`: render an issue template and create the GitHub issue from the body file.
 - `create_pr_from_template.py`: render a PR template and create the GitHub PR from the body file.
+- `validate_pr_body.py`: validate a PR body against the Ora et Labora PR template contract.
 - `init_issue_workspace.py`: initialize `00_brainstorm.md`, `CURRENT.md`, and task log.
-- `bootstrap_repo_templates.py`: copy GitHub templates, blueprint docs, and workflow examples into a target repo.
+- `bootstrap_repo_templates.py`: copy GitHub templates, blueprint docs, the standalone PR-body workflow, and workflow examples into a target repo.
 - `bootstrap_repo_templates.py --visibility <profile>`: also writes the profile-aware artifact policy into `.gitignore`.
 - `collect_playwright_artifacts.py`: collect browser verification artifacts into `.project/logs/playwright/<module-id>/<run-id>/`.
 

--- a/skills/ora-et-labora/assets/bootstrap/.github/ISSUE_TEMPLATE/config.yml
+++ b/skills/ora-et-labora/assets/bootstrap/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/skills/ora-et-labora/assets/bootstrap/.github/PULL_REQUEST_TEMPLATE.md
+++ b/skills/ora-et-labora/assets/bootstrap/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,19 @@
 - Browser:
 - CI:
 
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: no
+- Target branch:
+- Gates checked:
+  - [ ] PR targets `dev`
+  - [ ] PR is not a release PR into `main`
+  - [ ] Branch is current with `origin/dev`
+  - [ ] Required CI is passing or pending under GitHub auto-merge
+  - [ ] No requested changes, unresolved threads, blocked labels, or explicit hold
+  - [ ] `Closes #` reference is present
+  - [ ] Branch-local `.project` state is current
+
 ## Blueprint Updates
 
 ## Risks / Rollback

--- a/skills/ora-et-labora/assets/bootstrap/.github/workflows/validate-pr-body.yml
+++ b/skills/ora-et-labora/assets/bootstrap/.github/workflows/validate-pr-body.yml
@@ -1,0 +1,20 @@
+name: Validate PR Body
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+
+jobs:
+  validate-pr-body:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Validate PR body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+        run: python scripts/validate_pr_body.py --body "$PR_BODY"

--- a/skills/ora-et-labora/assets/bootstrap/.github/workflows/validate-pr-body.yml
+++ b/skills/ora-et-labora/assets/bootstrap/.github/workflows/validate-pr-body.yml
@@ -17,4 +17,5 @@ jobs:
       - name: Validate PR body
         env:
           PR_BODY: ${{ github.event.pull_request.body || '' }}
-        run: python scripts/validate_pr_body.py --body "$PR_BODY"
+          BASE_BRANCH: ${{ github.base_ref || '' }}
+        run: python scripts/validate_pr_body.py --body "$PR_BODY" --base-branch "$BASE_BRANCH"

--- a/skills/ora-et-labora/assets/templates/pr.md
+++ b/skills/ora-et-labora/assets/templates/pr.md
@@ -17,6 +17,10 @@
 - Browser evidence: {{BROWSER_EVIDENCE}}
 - CI: {{CI_VERIFICATION}}
 
+## Auto-Merge Eligibility
+
+{{AUTO_MERGE_ELIGIBILITY}}
+
 ## Blueprint Updates
 
 {{BLUEPRINT_UPDATES}}

--- a/skills/ora-et-labora/scripts/bootstrap_repo_templates.py
+++ b/skills/ora-et-labora/scripts/bootstrap_repo_templates.py
@@ -76,6 +76,13 @@ def copy_tree(src_root: Path, dst_root: Path, force: bool) -> None:
         shutil.copyfile(src, dst)
 
 
+def copy_file(src: Path, dst: Path, force: bool) -> None:
+    if dst.exists() and not force:
+        raise SystemExit(f"Refusing to overwrite existing file without --force: {dst}")
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
+
+
 def artifact_policy_block(visibility: str) -> str:
     lines = [BEGIN_MARKER, f"# Visibility profile: {visibility}"]
     lines.extend(GITIGNORE_PROFILES[visibility])
@@ -110,6 +117,11 @@ def main() -> int:
     skill_root = Path(__file__).resolve().parents[1]
     bootstrap_root = skill_root / "assets" / "bootstrap"
     copy_tree(bootstrap_root, args.repo_root, args.force)
+    copy_file(
+        skill_root / "scripts" / "validate_pr_body.py",
+        args.repo_root / "scripts" / "validate_pr_body.py",
+        args.force,
+    )
     if not args.skip_gitignore:
         upsert_gitignore_policy(args.repo_root, args.visibility)
     return 0

--- a/skills/ora-et-labora/scripts/create_issue_from_template.py
+++ b/skills/ora-et-labora/scripts/create_issue_from_template.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Render an issue template and create a GitHub issue from the body file."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from render_template import parse_vars, render
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--template", type=Path, required=True)
+    parser.add_argument("--body-out", type=Path, required=True)
+    parser.add_argument("--label", action="append", default=[])
+    parser.add_argument("--var", action="append", default=[], metavar="KEY=VALUE")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    body = render(args.template.read_text(), parse_vars(args.var))
+    args.body_out.parent.mkdir(parents=True, exist_ok=True)
+    args.body_out.write_text(body)
+
+    if args.dry_run:
+        print(args.body_out)
+        return 0
+
+    cmd = [
+        "gh",
+        "issue",
+        "create",
+        "--repo",
+        args.repo,
+        "--title",
+        args.title,
+        "--body-file",
+        str(args.body_out),
+    ]
+    for label in args.label:
+        cmd.extend(["--label", label])
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    print(result.stdout.strip())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ora-et-labora/scripts/create_pr_from_template.py
+++ b/skills/ora-et-labora/scripts/create_pr_from_template.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Render a PR template and create a GitHub pull request from the body file."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from render_template import parse_vars, render
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--template", type=Path, required=True)
+    parser.add_argument("--body-out", type=Path, required=True)
+    parser.add_argument("--var", action="append", default=[], metavar="KEY=VALUE")
+    parser.add_argument("--draft", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    body = render(args.template.read_text(), parse_vars(args.var))
+    args.body_out.parent.mkdir(parents=True, exist_ok=True)
+    args.body_out.write_text(body)
+
+    if args.dry_run:
+        print(args.body_out)
+        return 0
+
+    cmd = [
+        "gh",
+        "pr",
+        "create",
+        "--repo",
+        args.repo,
+        "--base",
+        args.base,
+        "--head",
+        args.head,
+        "--title",
+        args.title,
+        "--body-file",
+        str(args.body_out),
+    ]
+    if args.draft:
+        cmd.append("--draft")
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    print(result.stdout.strip())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ora-et-labora/scripts/validate_pr_body.py
+++ b/skills/ora-et-labora/scripts/validate_pr_body.py
@@ -17,6 +17,19 @@ REQUIRED_VERIFICATION_PREFIXES = (
     "- Browser evidence:",
     "- CI:",
 )
+REQUIRED_RELEASE_CHECK_PREFIXES = (
+    "- Regression:",
+    "- Browser verification:",
+    "- CI status:",
+    "- Migrations / schema:",
+)
+RELEASE_REQUIRED_HEADERS = (
+    "## Release Scope",
+    "## Included PRs",
+    "## Release Checks",
+    "## Notes",
+    "## Rollback",
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -24,6 +37,7 @@ def parse_args() -> argparse.Namespace:
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--body-file", type=Path)
     group.add_argument("--body")
+    parser.add_argument("--base-branch", default="")
     parser.add_argument("--template", type=Path)
     return parser.parse_args()
 
@@ -58,7 +72,12 @@ def extract_sections(body: str) -> dict[str, str]:
     return sections
 
 
-def validate_body(body: str, template_path: Path) -> list[str]:
+def validate_body(
+    body: str,
+    template_path: Optional[Path],
+    *,
+    mode: str = "implementation",
+) -> list[str]:
     errors: list[str] = []
 
     placeholders = sorted(set(PLACEHOLDER_RE.findall(body)))
@@ -68,7 +87,13 @@ def validate_body(body: str, template_path: Path) -> list[str]:
         )
 
     sections = extract_sections(body)
-    required_headers = load_required_headers(template_path)
+    if template_path is not None:
+        required_headers = load_required_headers(template_path)
+    elif mode == "release":
+        required_headers = list(RELEASE_REQUIRED_HEADERS)
+    else:
+        raise ValueError("template_path is required for implementation PR validation")
+
     for header in required_headers:
         if header not in sections:
             errors.append(f"Missing required section header: {header}")
@@ -76,19 +101,25 @@ def validate_body(body: str, template_path: Path) -> list[str]:
         if not sections[header]:
             errors.append(f"Section is empty: {header}")
 
-    linked_issue = sections.get("## Linked Issue", "")
-    if linked_issue and not re.search(r"(?im)\bcloses\s+#\d+\b", linked_issue):
-        errors.append("Linked Issue section must contain a `Closes #<issue>` reference.")
+    if mode == "implementation":
+        linked_issue = sections.get("## Linked Issue", "")
+        if linked_issue and not re.search(r"(?im)\bcloses\s+#\d+\b", linked_issue):
+            errors.append("Linked Issue section must contain a `Closes #<issue>` reference.")
 
-    verification = sections.get("## Verification", "")
-    for prefix in REQUIRED_VERIFICATION_PREFIXES:
-        if verification and prefix not in verification:
-            errors.append(f"Verification section is missing required line prefix: {prefix}")
+        verification = sections.get("## Verification", "")
+        for prefix in REQUIRED_VERIFICATION_PREFIXES:
+            if verification and prefix not in verification:
+                errors.append(f"Verification section is missing required line prefix: {prefix}")
+    else:
+        release_checks = sections.get("## Release Checks", "")
+        for prefix in REQUIRED_RELEASE_CHECK_PREFIXES:
+            if release_checks and prefix not in release_checks:
+                errors.append(f"Release Checks section is missing required line prefix: {prefix}")
 
     return errors
 
 
-def default_template_path(script_path: Path) -> Path:
+def default_implementation_template_path(script_path: Path) -> Path:
     candidates = [
         script_path.resolve().parents[1] / "assets" / "templates" / "pr.md",
         script_path.resolve().parents[1] / ".github" / "PULL_REQUEST_TEMPLATE.md",
@@ -102,17 +133,43 @@ def default_template_path(script_path: Path) -> Path:
     )
 
 
+def default_release_template_path(script_path: Path) -> Optional[Path]:
+    candidates = [
+        script_path.resolve().parents[1] / "assets" / "templates" / "release-pr.md",
+        script_path.resolve().parents[1] / ".github" / "release-pr.md",
+        script_path.resolve().parents[2] / ".github" / "release-pr.md",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def resolve_mode(base_branch: str, body: str) -> str:
+    if base_branch == "main":
+        return "release"
+    if "## Release Scope" in body and "## Release Checks" in body:
+        return "release"
+    return "implementation"
+
+
 def main() -> int:
     args = parse_args()
-    template_path = args.template or default_template_path(Path(__file__))
     body = load_body(args)
-    errors = validate_body(body, template_path)
+    mode = resolve_mode(args.base_branch.strip(), body)
+    if args.template is not None:
+        template_path = args.template
+    elif mode == "release":
+        template_path = default_release_template_path(Path(__file__))
+    else:
+        template_path = default_implementation_template_path(Path(__file__))
+    errors = validate_body(body, template_path, mode=mode)
     if errors:
         for error in errors:
             print(f"ERROR: {error}", file=sys.stderr)
         return 1
 
-    print("PR body matches the Ora et Labora template contract.")
+    print(f"PR body matches the Ora et Labora {mode} PR contract.")
     return 0
 
 

--- a/skills/ora-et-labora/scripts/validate_pr_body.py
+++ b/skills/ora-et-labora/scripts/validate_pr_body.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Validate a PR body against the Ora et Labora PR template contract."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+PLACEHOLDER_RE = re.compile(r"\{\{[^}]+\}\}")
+REQUIRED_VERIFICATION_PREFIXES = (
+    "- Local:",
+    "- Browser:",
+    "- Browser evidence:",
+    "- CI:",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--body-file", type=Path)
+    group.add_argument("--body")
+    parser.add_argument("--template", type=Path)
+    return parser.parse_args()
+
+
+def load_body(args: argparse.Namespace) -> str:
+    if args.body_file is not None:
+        return args.body_file.read_text()
+    return args.body
+
+
+def load_required_headers(template_path: Path) -> list[str]:
+    return [line.strip() for line in template_path.read_text().splitlines() if line.startswith("## ")]
+
+
+def extract_sections(body: str) -> dict[str, str]:
+    sections: dict[str, str] = {}
+    current_header: Optional[str] = None
+    current_lines: list[str] = []
+
+    for line in body.splitlines():
+        if line.startswith("## "):
+            if current_header is not None:
+                sections[current_header] = "\n".join(current_lines).strip()
+            current_header = line.strip()
+            current_lines = []
+            continue
+        if current_header is not None:
+            current_lines.append(line)
+
+    if current_header is not None:
+        sections[current_header] = "\n".join(current_lines).strip()
+    return sections
+
+
+def validate_body(body: str, template_path: Path) -> list[str]:
+    errors: list[str] = []
+
+    placeholders = sorted(set(PLACEHOLDER_RE.findall(body)))
+    if placeholders:
+        errors.append(
+            "PR body contains unresolved template placeholders: " + ", ".join(placeholders)
+        )
+
+    sections = extract_sections(body)
+    required_headers = load_required_headers(template_path)
+    for header in required_headers:
+        if header not in sections:
+            errors.append(f"Missing required section header: {header}")
+            continue
+        if not sections[header]:
+            errors.append(f"Section is empty: {header}")
+
+    linked_issue = sections.get("## Linked Issue", "")
+    if linked_issue and not re.search(r"(?im)\bcloses\s+#\d+\b", linked_issue):
+        errors.append("Linked Issue section must contain a `Closes #<issue>` reference.")
+
+    verification = sections.get("## Verification", "")
+    for prefix in REQUIRED_VERIFICATION_PREFIXES:
+        if verification and prefix not in verification:
+            errors.append(f"Verification section is missing required line prefix: {prefix}")
+
+    return errors
+
+
+def default_template_path(script_path: Path) -> Path:
+    candidates = [
+        script_path.resolve().parents[1] / "assets" / "templates" / "pr.md",
+        script_path.resolve().parents[1] / ".github" / "PULL_REQUEST_TEMPLATE.md",
+        script_path.resolve().parents[2] / ".github" / "PULL_REQUEST_TEMPLATE.md",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(
+        "Could not locate a PR template. Pass --template explicitly or ensure the Ora et Labora PR template is present."
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    template_path = args.template or default_template_path(Path(__file__))
+    body = load_body(args)
+    errors = validate_body(body, template_path)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print("PR body matches the Ora et Labora template contract.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/release-train/SKILL.md
+++ b/skills/release-train/SKILL.md
@@ -91,6 +91,7 @@ Do not merge every feature/fix PR directly into `main`. That defeats grouped rel
 5. Prepare release PR body.
    - Use `../ora-et-labora/assets/templates/release-pr.md`.
    - Prefer a body file and `gh pr create --body-file <file>`.
+   - The PR-body validation gate accepts the release template shape for PRs targeting `main`; do not rewrite release PRs into the implementation template just to satisfy CI.
    - Do not assemble complex markdown inline in shell strings.
 6. Open or update the release PR.
    - Base: `main`.

--- a/skills/release-train/SKILL.md
+++ b/skills/release-train/SKILL.md
@@ -100,6 +100,8 @@ Do not merge every feature/fix PR directly into `main`. That defeats grouped rel
    - Do not duplicate the entire release PR body in local logs.
 8. Merge only when release gates are satisfied.
    - If gates are blocked, record blocker and do not claim release readiness.
+   - Release PRs into `main` require explicit user approval before merge.
+   - Do not enable auto-merge for release PRs unless the user explicitly approves auto-merge for that specific release PR.
 
 ## Release Checks
 
@@ -113,6 +115,7 @@ Run or confirm:
 - deployment or runtime config checks if relevant
 - release-note accuracy
 - rollback plan plausibility
+- explicit user approval before merging a release PR into `main`
 
 If a check is skipped, the release PR must say why.
 
@@ -157,6 +160,7 @@ Weak rollback notes:
 - Rollback says only "revert if needed."
 - The release is being made by merging each implementation PR separately to `main`.
 - The release uses stale verification from before recent `dev` merges.
+- Auto-merge is enabled for a release PR into `main` without explicit user approval.
 
 All of these mean the release train is not ready.
 
@@ -169,6 +173,7 @@ All of these mean the release train is not ready.
 | "Rollback is obvious." | If it is obvious, write the concrete rollback action. |
 | "No browser check is needed because frontend PRs were already reviewed." | Review is not browser verification. Include current browser status or explain why not needed. |
 | "We can promote directly from feature branch to `main`." | Normal flow is implementation to `dev`, release train to `main`, unless explicitly overridden. |
+| "Checks are green, so the release PR can auto-merge." | `main` is stable. Release merges require explicit user approval unless the user approved auto-merge for that specific release PR. |
 
 ## Template And Tools
 
@@ -186,6 +191,7 @@ Use the template as the release body structure. Fill unknown statuses explicitly
 - operational notes captured when runtime/deploy changed
 - rollback plan concrete
 - release PR targets `main`
+- explicit user approval recorded before merge
 - release state recorded without duplicating the entire PR body locally
 
 ## Common Mistakes
@@ -194,5 +200,6 @@ Use the template as the release body structure. Fill unknown statuses explicitly
 - forgetting rollback notes
 - using stale verification status that no longer reflects current `dev`
 - failing to identify included PRs
+- auto-merging a release PR into `main` without explicit user approval
 - treating release notes as optional when users or operators need them
 - merging a release train while required checks are still pending

--- a/skills/repo-bootstrap/SKILL.md
+++ b/skills/repo-bootstrap/SKILL.md
@@ -53,6 +53,7 @@ Do not use this skill when:
 | --- | --- |
 | Bug issue template | `.github/ISSUE_TEMPLATE/bug_report.md` |
 | Feature issue template | `.github/ISSUE_TEMPLATE/feature_request.md` |
+| Issue template config | `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false` |
 | PR template | `.github/PULL_REQUEST_TEMPLATE.md` with a `Linked Issue` / `Closes #` section |
 | CI placeholder | `.github/workflows/ci.yml.example` |
 | Release placeholder | `.github/workflows/release.yml.example` |
@@ -174,6 +175,7 @@ Issue and PR formatting should be deterministic.
 Use:
 
 - templates under `.github/`
+- issue template config under `.github/ISSUE_TEMPLATE/config.yml`
 - body files
 - `gh issue create --body-file <file>`
 - `gh pr create --body-file <file>`
@@ -260,6 +262,7 @@ Use the script for baseline copying. Inspect and adapt the copied files before c
 
 - existing repo workflow inspected
 - `.github/ISSUE_TEMPLATE/` present or intentionally skipped
+- `.github/ISSUE_TEMPLATE/config.yml` disables blank issues unless intentionally overridden
 - `.github/PULL_REQUEST_TEMPLATE.md` present or intentionally skipped
 - PR template contains a linked issue / closing keyword section
 - visibility profile selected and represented in `.gitignore`

--- a/skills/repo-bootstrap/SKILL.md
+++ b/skills/repo-bootstrap/SKILL.md
@@ -55,6 +55,8 @@ Do not use this skill when:
 | Feature issue template | `.github/ISSUE_TEMPLATE/feature_request.md` |
 | Issue template config | `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false` |
 | PR template | `.github/PULL_REQUEST_TEMPLATE.md` with a `Linked Issue` / `Closes #` section |
+| PR body validation workflow | `.github/workflows/validate-pr-body.yml` |
+| PR body validator script | `scripts/validate_pr_body.py` |
 | CI placeholder | `.github/workflows/ci.yml.example` |
 | Release placeholder | `.github/workflows/release.yml.example` |
 | Workflow blueprint | `.project/blueprint/00_workflow.md` |
@@ -105,6 +107,7 @@ Private/internal profile rule: `.project/` may be versioned, but raw browser art
    - Pass `--visibility <profile>` so `.gitignore` receives the right artifact policy.
    - Use `--force` only when overwrite is explicitly intended.
 4. Adapt placeholders.
+   - Keep the standalone PR-body validation workflow active unless the repo already has an equivalent stronger gate.
    - Replace example CI commands with project-specific commands.
    - Replace release placeholders with real release checks when known.
    - Do not leave misleading CI or release placeholders that appear production-ready.

--- a/skills/verify-and-evidence/SKILL.md
+++ b/skills/verify-and-evidence/SKILL.md
@@ -122,6 +122,7 @@ CI/release:
 - check current CI status, not stale runs
 - distinguish "not run", "pending", "failed", and "passed"
 - for release trains, include regression, browser, migration/schema, and rollback readiness where relevant
+- for auto-merge, confirm current CI, review state, branch freshness, issue closure reference, and mergeability before enabling or performing the merge
 
 ## Browser Verification Is Required When
 
@@ -133,6 +134,22 @@ CI/release:
 - screenshots, traces, or videos are needed to prove the fix
 
 Browser verification may be skipped only when the change is provably not browser-visible, such as a backend-only test fixture or documentation-only update. If skipped, record why.
+
+## Auto-Merge Readiness
+
+Before enabling `gh pr merge --auto` or performing an immediate merge, verify the PR is actually eligible:
+
+- target branch is `dev`
+- PR is not a release PR into `main`
+- latest branch state is rebased on `origin/dev`
+- required CI is passing or pending under GitHub auto-merge
+- no requested changes, unresolved review threads, merge conflicts, blocked labels, or explicit user hold are present
+- local verification in the PR body matches the changed surface
+- browser evidence is present when frontend-visible behavior changed
+- PR body includes `Closes #<issue>` or an equivalent closing keyword
+- `CURRENT.md` and the task log record the latest verification and auto-merge decision
+
+If any item is unknown, treat auto-merge as blocked. Record the gap instead of enabling auto-merge optimistically.
 
 ## Playwright Artifact Policy
 
@@ -181,6 +198,7 @@ In the task log:
 - verification failed with a new meaningful reason
 - browser evidence was collected
 - CI result changed in a way that affects readiness
+- auto-merge was enabled, skipped, blocked, or completed
 
 In the PR:
 
@@ -188,6 +206,7 @@ In the PR:
 - browser check summary
 - browser evidence path
 - CI status
+- auto-merge eligibility or explicit reason it is not requested
 - verification gaps or skipped checks with reason
 
 ## Red Flags - Verification Not Good Enough
@@ -196,6 +215,7 @@ In the PR:
 - "I checked it manually" without artifact or exact path.
 - "The browser behavior should be fixed because the code changed."
 - "CI passed yesterday before the rebase."
+- "Auto-merge is enabled, so current verification no longer matters."
 - "The screenshot is in `/tmp` and not preserved."
 - "Frontend changed, but no browser verification was run."
 - "Docker services changed, but the old containers were used."

--- a/skills/worktree-flow/SKILL.md
+++ b/skills/worktree-flow/SKILL.md
@@ -56,7 +56,9 @@ Do not use this skill for:
 | Worktree path | `.project/worktrees/<branch-id-without-slashes>` |
 | Implementation PR base | `dev` |
 | Implementation PR issue link | `Closes #<issue-id>` in the PR body |
+| Implementation PR auto-merge | allowed only when all auto-merge gates are satisfied |
 | Stable release PR base | `main` |
+| Release PR auto-merge | never without explicit user approval |
 | Default Docker mode | one active stack across worktrees |
 | Parallel Docker mode | only with isolated project names, ports, and container/service names |
 
@@ -122,6 +124,28 @@ Before marking a PR ready:
 - PR body contains a closing reference to the originating issue, such as `Closes #123`
 - PR body is rendered from a body file or template
 - branch-local `.project` state points to the PR
+
+## Auto-Merge Policy
+
+Implementation PRs into `dev` may use agent auto-merge when every gate below is satisfied. This policy is permission to use GitHub's merge machinery when safe; it is not permission to bypass repository rules, required checks, branch protection, review requirements, or an explicit user hold.
+
+Auto-merge gates for implementation PRs:
+
+- PR target is `dev`, not `main`.
+- PR is not a release PR, hotfix-to-stable PR, or emergency production promotion.
+- PR body includes a closing reference for the originating issue, such as `Closes #123`.
+- Branch is rebased on current `origin/dev`.
+- Local verification is recorded in `CURRENT.md`, the task log, and the PR body.
+- Browser evidence exists when frontend-visible behavior changed, or the PR body explains why browser verification is not applicable.
+- Required CI is passing, or GitHub auto-merge is enabled while required CI is pending.
+- No unresolved review threads, requested changes, merge conflicts, blocked labels, or explicit user hold are present.
+- Branch-local `.project` state points to the PR and records the auto-merge decision.
+
+Use `gh pr merge --auto --merge` when required checks are still pending and GitHub auto-merge is available. Use an immediate merge command only when checks are already green and all gates are satisfied.
+
+If GitHub auto-merge is unavailable, blocked by settings, or rejected by branch protection, do not force the merge. Record the blocker and leave the PR open.
+
+Release PRs into `main` require explicit user approval before merge, even when checks are green. Do not enable auto-merge for release PRs unless the user explicitly says to enable auto-merge for that specific release PR.
 
 ## Docker Runtime Model
 
@@ -193,6 +217,8 @@ Do not let two worktrees silently modify the same contract without surfacing ove
 - "The PR targets `main` for normal implementation work."
 - "The PR references the issue in prose but does not use a closing keyword."
 - "I pushed before rebasing on `origin/dev`."
+- "I enabled auto-merge without checking reviews, CI, issue closure, and branch freshness."
+- "I enabled auto-merge for a release PR into `main` without explicit user approval."
 - "The browser is still using the old dev server."
 - "Two worktrees run Compose with the same ports."
 - "The repo has fixed `container_name` values but I started parallel stacks."
@@ -210,6 +236,7 @@ All of these mean the branch/worktree flow is unsafe.
 | "The branch is close enough to `dev`." | Rebase gates exist because stale branches hide conflicts and CI drift. |
 | "A direct merge is faster." | PR-first integration is the safety surface unless the user explicitly overrides it. |
 | "I can close the issue manually after merge." | The PR should carry `Closes #<issue>` so GitHub closes it automatically and auditably on merge. |
+| "Auto-merge means GitHub will handle everything." | Auto-merge only waits for GitHub gates. The agent must still confirm branch freshness, verification, reviews, issue closure, and state logging. |
 
 ## Completion Checklist
 
@@ -223,6 +250,7 @@ All of these mean the branch/worktree flow is unsafe.
 - PR body uses `Closes #<issue-id>` or an equivalent closing keyword for the originating issue
 - PR body comes from a file or template
 - verification is complete before PR readiness
+- auto-merge is enabled only for eligible `dev` PRs, or explicitly skipped/blocked in the task log
 
 ## Common Mistakes
 
@@ -231,6 +259,7 @@ All of these mean the branch/worktree flow is unsafe.
 - working from the main checkout after creating a worktree
 - opening implementation PRs directly to `main`
 - forgetting the closing issue reference in the PR body
+- enabling auto-merge on release PRs into `main` without explicit user approval
 - failing to rebase after another PR merges to `dev`
 - trusting stale browser or container state after code sync
 

--- a/skills/worktree-flow/SKILL.md
+++ b/skills/worktree-flow/SKILL.md
@@ -96,7 +96,9 @@ Worktree folder names should avoid slashes:
    - Write `.project/todo`, `.project/logs`, and `.project/blueprint` in the assigned worktree checkout for branch work.
 6. Open a draft PR early when the branch will be active for more than a tiny fix.
    - Base: `dev`.
-   - Use a body file or template, not inline shell markdown.
+   - Standard path: use `../ora-et-labora/scripts/create_pr_from_template.py`.
+   - Minimum fallback: render a body file first, then use `gh pr create --body-file <file>`.
+   - Do not hand-write multi-section PR markdown directly into `gh pr create`.
    - Include `Closes #<issue-id>` or an equivalent GitHub closing keyword for the originating issue.
 7. Rebase on `origin/dev` at required gates.
    - At session start in that worktree.
@@ -122,7 +124,7 @@ Before marking a PR ready:
 - browser evidence exists for frontend behavior changes
 - Docker/runtime state was rebuilt or restarted after sync when relevant
 - PR body contains a closing reference to the originating issue, such as `Closes #123`
-- PR body is rendered from a body file or template
+- PR body is rendered through the wrapper script or from a rendered body file
 - branch-local `.project` state points to the PR
 
 ## Auto-Merge Policy
@@ -248,7 +250,7 @@ All of these mean the branch/worktree flow is unsafe.
 - Docker mode is clear: default one-stack or isolated parallel mode
 - PR targets `dev`
 - PR body uses `Closes #<issue-id>` or an equivalent closing keyword for the originating issue
-- PR body comes from a file or template
+- PR body comes from `create_pr_from_template.py` or a rendered body file
 - verification is complete before PR readiness
 - auto-merge is enabled only for eligible `dev` PRs, or explicitly skipped/blocked in the task log
 

--- a/skills/worktree-flow/SKILL.md
+++ b/skills/worktree-flow/SKILL.md
@@ -250,7 +250,8 @@ All of these mean the branch/worktree flow is unsafe.
 - Docker mode is clear: default one-stack or isolated parallel mode
 - PR targets `dev`
 - PR body uses `Closes #<issue-id>` or an equivalent closing keyword for the originating issue
-- PR body comes from `create_pr_from_template.py` or a rendered body file
+   - PR body comes from `create_pr_from_template.py` or a rendered body file
+   - GitHub `validate` rejects PRs whose bodies are missing required template sections or the `Closes #<issue>` reference
 - verification is complete before PR readiness
 - auto-merge is enabled only for eligible `dev` PRs, or explicitly skipped/blocked in the task log
 

--- a/tests/test_auto_merge_policy.py
+++ b/tests/test_auto_merge_policy.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class AutoMergePolicyTests(unittest.TestCase):
+    def test_worktree_flow_defines_dev_auto_merge_gates(self) -> None:
+        text = (REPO_ROOT / "skills" / "worktree-flow" / "SKILL.md").read_text()
+        self.assertIn("## Auto-Merge Policy", text)
+        self.assertIn("gh pr merge --auto", text)
+        self.assertIn("release PRs into `main`", text)
+        self.assertIn("explicit user approval", text)
+
+    def test_suite_index_exposes_auto_merge_policy(self) -> None:
+        text = (REPO_ROOT / "skills" / "ora-et-labora" / "SKILL.md").read_text()
+        self.assertIn("Implementation PRs into `dev` may use agent auto-merge", text)
+        self.assertIn("Release PRs into `main` require explicit user approval", text)
+
+    def test_pr_templates_include_auto_merge_eligibility(self) -> None:
+        bootstrap_template = (
+            REPO_ROOT
+            / "skills"
+            / "ora-et-labora"
+            / "assets"
+            / "bootstrap"
+            / ".github"
+            / "PULL_REQUEST_TEMPLATE.md"
+        ).read_text()
+        rendered_template = (
+            REPO_ROOT / "skills" / "ora-et-labora" / "assets" / "templates" / "pr.md"
+        ).read_text()
+        self.assertIn("## Auto-Merge Eligibility", bootstrap_template)
+        self.assertIn("Agent auto-merge requested", bootstrap_template)
+        self.assertIn("## Auto-Merge Eligibility", rendered_template)
+        self.assertIn("{{AUTO_MERGE_ELIGIBILITY}}", rendered_template)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bootstrap_repo_templates.py
+++ b/tests/test_bootstrap_repo_templates.py
@@ -25,10 +25,13 @@ class BootstrapRepoTemplatesTests(unittest.TestCase):
             )
 
             self.assertTrue((repo_root / ".github" / "PULL_REQUEST_TEMPLATE.md").exists())
+            self.assertTrue((repo_root / ".github" / "ISSUE_TEMPLATE" / "config.yml").exists())
             self.assertTrue((repo_root / ".project" / "blueprint" / "00_workflow.md").exists())
             pr_template = (repo_root / ".github" / "PULL_REQUEST_TEMPLATE.md").read_text()
+            issue_config = (repo_root / ".github" / "ISSUE_TEMPLATE" / "config.yml").read_text()
             self.assertIn("## Linked Issue", pr_template)
             self.assertIn("Closes #", pr_template)
+            self.assertIn("blank_issues_enabled: false", issue_config)
             gitignore = (repo_root / ".gitignore").read_text()
             self.assertIn("Visibility profile: private", gitignore)
             self.assertIn(".project/worktrees/", gitignore)

--- a/tests/test_bootstrap_repo_templates.py
+++ b/tests/test_bootstrap_repo_templates.py
@@ -90,6 +90,45 @@ Revert the bootstrap if needed.
                 cwd=repo_root,
             )
 
+            release_body = repo_root / "release-body.md"
+            release_body.write_text(
+                """## Release Scope
+
+- Promote a workflow-only release to main.
+
+## Included PRs
+
+- #1
+
+## Release Checks
+
+- Regression: smoke
+- Browser verification: not applicable
+- CI status: pending
+- Migrations / schema: not applicable
+
+## Notes
+
+- Workflow-only release.
+
+## Rollback
+
+Revert the release merge commit on main if needed.
+"""
+            )
+            subprocess.run(
+                [
+                    "python",
+                    str(repo_root / "scripts" / "validate_pr_body.py"),
+                    "--body-file",
+                    str(release_body),
+                    "--base-branch",
+                    "main",
+                ],
+                check=True,
+                cwd=repo_root,
+            )
+
     def test_public_visibility_keeps_project_state_local(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)

--- a/tests/test_bootstrap_repo_templates.py
+++ b/tests/test_bootstrap_repo_templates.py
@@ -26,16 +26,69 @@ class BootstrapRepoTemplatesTests(unittest.TestCase):
 
             self.assertTrue((repo_root / ".github" / "PULL_REQUEST_TEMPLATE.md").exists())
             self.assertTrue((repo_root / ".github" / "ISSUE_TEMPLATE" / "config.yml").exists())
+            self.assertTrue((repo_root / ".github" / "workflows" / "validate-pr-body.yml").exists())
             self.assertTrue((repo_root / ".project" / "blueprint" / "00_workflow.md").exists())
+            self.assertTrue((repo_root / "scripts" / "validate_pr_body.py").exists())
             pr_template = (repo_root / ".github" / "PULL_REQUEST_TEMPLATE.md").read_text()
             issue_config = (repo_root / ".github" / "ISSUE_TEMPLATE" / "config.yml").read_text()
+            pr_workflow = (repo_root / ".github" / "workflows" / "validate-pr-body.yml").read_text()
             self.assertIn("## Linked Issue", pr_template)
             self.assertIn("Closes #", pr_template)
             self.assertIn("blank_issues_enabled: false", issue_config)
+            self.assertIn("python scripts/validate_pr_body.py", pr_workflow)
             gitignore = (repo_root / ".gitignore").read_text()
             self.assertIn("Visibility profile: private", gitignore)
             self.assertIn(".project/worktrees/", gitignore)
             self.assertNotIn("\n.project/\n", f"\n{gitignore}")
+
+            body = repo_root / "body.md"
+            body.write_text(
+                """## Summary
+
+- Bootstrapped smoke test.
+
+## Why
+
+Ensure the copied validator runs in a target repo.
+
+## Linked Issue
+
+Closes #1
+
+## Verification
+
+- Local: smoke
+- Browser: not applicable
+- Browser evidence: not applicable
+- CI: pending
+
+## Auto-Merge Eligibility
+
+- Not applicable.
+
+## Blueprint Updates
+
+None.
+
+## Risks / Rollback
+
+Revert the bootstrap if needed.
+
+## Follow-ups
+
+- None.
+"""
+            )
+            subprocess.run(
+                [
+                    "python",
+                    str(repo_root / "scripts" / "validate_pr_body.py"),
+                    "--body-file",
+                    str(body),
+                ],
+                check=True,
+                cwd=repo_root,
+            )
 
     def test_public_visibility_keeps_project_state_local(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_create_issue_from_template.py
+++ b/tests/test_create_issue_from_template.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "skills" / "ora-et-labora" / "scripts" / "create_issue_from_template.py"
+
+
+class CreateIssueFromTemplateTests(unittest.TestCase):
+    def test_renders_issue_body_in_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            template = tmpdir / "issue.md"
+            body_out = tmpdir / "body.md"
+            template.write_text("Problem: {{PROBLEM}}\n")
+            subprocess.run(
+                [
+                    "python",
+                    str(SCRIPT),
+                    "--repo",
+                    "owner/repo",
+                    "--title",
+                    "Example issue",
+                    "--template",
+                    str(template),
+                    "--body-out",
+                    str(body_out),
+                    "--var",
+                    "PROBLEM=missing template enforcement",
+                    "--dry-run",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(body_out.read_text(), "Problem: missing template enforcement\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_create_pr_from_template.py
+++ b/tests/test_create_pr_from_template.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "skills" / "ora-et-labora" / "scripts" / "create_pr_from_template.py"
+
+
+class CreatePrFromTemplateTests(unittest.TestCase):
+    def test_renders_pr_body_in_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            template = tmpdir / "pr.md"
+            body_out = tmpdir / "body.md"
+            template.write_text("Summary: {{SUMMARY}}\n")
+            subprocess.run(
+                [
+                    "python",
+                    str(SCRIPT),
+                    "--repo",
+                    "owner/repo",
+                    "--title",
+                    "Example pr",
+                    "--base",
+                    "dev",
+                    "--head",
+                    "feat/example",
+                    "--template",
+                    str(template),
+                    "--body-out",
+                    str(body_out),
+                    "--var",
+                    "SUMMARY=template-enforced pr",
+                    "--dry-run",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(body_out.read_text(), "Summary: template-enforced pr\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_template_enforcement_policy.py
+++ b/tests/test_template_enforcement_policy.py
@@ -35,6 +35,7 @@ class TemplateEnforcementPolicyTests(unittest.TestCase):
         workflow = (REPO_ROOT / ".github" / "workflows" / "validate.yml").read_text()
         self.assertIn("Validate PR body", workflow)
         self.assertIn("skills/ora-et-labora/scripts/validate_pr_body.py", workflow)
+        self.assertIn("--base-branch \"$BASE_BRANCH\"", workflow)
 
     def test_skill_contains_pr_body_validator(self) -> None:
         validator = (REPO_ROOT / "skills" / "ora-et-labora" / "scripts" / "validate_pr_body.py")

--- a/tests/test_template_enforcement_policy.py
+++ b/tests/test_template_enforcement_policy.py
@@ -34,7 +34,11 @@ class TemplateEnforcementPolicyTests(unittest.TestCase):
     def test_validate_workflow_runs_pr_body_gate(self) -> None:
         workflow = (REPO_ROOT / ".github" / "workflows" / "validate.yml").read_text()
         self.assertIn("Validate PR body", workflow)
-        self.assertIn("scripts/validate_pr_body.py", workflow)
+        self.assertIn("skills/ora-et-labora/scripts/validate_pr_body.py", workflow)
+
+    def test_skill_contains_pr_body_validator(self) -> None:
+        validator = (REPO_ROOT / "skills" / "ora-et-labora" / "scripts" / "validate_pr_body.py")
+        self.assertTrue(validator.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_template_enforcement_policy.py
+++ b/tests/test_template_enforcement_policy.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TemplateEnforcementPolicyTests(unittest.TestCase):
+    def test_issue_shaping_requires_issue_wrapper(self) -> None:
+        text = (REPO_ROOT / "skills" / "issue-shaping" / "SKILL.md").read_text()
+        self.assertIn("create_issue_from_template.py", text)
+
+    def test_worktree_flow_requires_pr_wrapper(self) -> None:
+        text = (REPO_ROOT / "skills" / "worktree-flow" / "SKILL.md").read_text()
+        self.assertIn("create_pr_from_template.py", text)
+
+    def test_suite_index_mentions_issue_and_pr_wrappers(self) -> None:
+        text = (REPO_ROOT / "skills" / "ora-et-labora" / "SKILL.md").read_text()
+        self.assertIn("create_issue_from_template.py", text)
+        self.assertIn("create_pr_from_template.py", text)
+
+    def test_wrapper_scripts_use_body_file_creation(self) -> None:
+        issue_script = (
+            REPO_ROOT / "skills" / "ora-et-labora" / "scripts" / "create_issue_from_template.py"
+        ).read_text()
+        pr_script = (
+            REPO_ROOT / "skills" / "ora-et-labora" / "scripts" / "create_pr_from_template.py"
+        ).read_text()
+        self.assertIn("--body-file", issue_script)
+        self.assertIn("--body-file", pr_script)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_template_enforcement_policy.py
+++ b/tests/test_template_enforcement_policy.py
@@ -31,6 +31,11 @@ class TemplateEnforcementPolicyTests(unittest.TestCase):
         self.assertIn("--body-file", issue_script)
         self.assertIn("--body-file", pr_script)
 
+    def test_validate_workflow_runs_pr_body_gate(self) -> None:
+        workflow = (REPO_ROOT / ".github" / "workflows" / "validate.yml").read_text()
+        self.assertIn("Validate PR body", workflow)
+        self.assertIn("scripts/validate_pr_body.py", workflow)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validate_pr_body.py
+++ b/tests/test_validate_pr_body.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-SCRIPT = REPO_ROOT / "scripts" / "validate_pr_body.py"
+SCRIPT = REPO_ROOT / "skills" / "ora-et-labora" / "scripts" / "validate_pr_body.py"
 SPEC = importlib.util.spec_from_file_location("validate_pr_body", SCRIPT)
 MODULE = importlib.util.module_from_spec(SPEC)
 assert SPEC is not None and SPEC.loader is not None

--- a/tests/test_validate_pr_body.py
+++ b/tests/test_validate_pr_body.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "validate_pr_body.py"
+SPEC = importlib.util.spec_from_file_location("validate_pr_body", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC is not None and SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+validate_body = MODULE.validate_body
+
+
+class ValidatePrBodyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.template = REPO_ROOT / "skills" / "ora-et-labora" / "assets" / "templates" / "pr.md"
+
+    def test_accepts_valid_body(self) -> None:
+        body = """## Summary
+
+- Adds a PR body validation gate.
+
+## Why
+
+This makes template structure a real CI requirement.
+
+## Linked Issue
+
+Closes #8
+
+## Verification
+
+- Local: `python scripts/validate_all.py`
+- Browser: not applicable
+- Browser evidence: not applicable
+- CI: pending after PR creation
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: yes, once required checks pass.
+
+## Blueprint Updates
+
+No blueprint updates required.
+
+## Risks / Rollback
+
+Rollback: revert this PR.
+
+## Follow-ups
+
+- Sync installed skills after merge.
+"""
+        self.assertEqual(validate_body(body, self.template), [])
+
+    def test_rejects_missing_section(self) -> None:
+        body = """## Summary
+
+- Adds a PR body validation gate.
+
+## Linked Issue
+
+Closes #8
+
+## Verification
+
+- Local: `python scripts/validate_all.py`
+- Browser: not applicable
+- Browser evidence: not applicable
+- CI: pending after PR creation
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: yes, once required checks pass.
+
+## Blueprint Updates
+
+No blueprint updates required.
+
+## Risks / Rollback
+
+Rollback: revert this PR.
+
+## Follow-ups
+
+- Sync installed skills after merge.
+"""
+        errors = validate_body(body, self.template)
+        self.assertIn("Missing required section header: ## Why", errors)
+
+    def test_rejects_missing_closes_reference(self) -> None:
+        body = """## Summary
+
+- Adds a PR body validation gate.
+
+## Why
+
+This makes template structure a real CI requirement.
+
+## Linked Issue
+
+References #8
+
+## Verification
+
+- Local: `python scripts/validate_all.py`
+- Browser: not applicable
+- Browser evidence: not applicable
+- CI: pending after PR creation
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: yes, once required checks pass.
+
+## Blueprint Updates
+
+No blueprint updates required.
+
+## Risks / Rollback
+
+Rollback: revert this PR.
+
+## Follow-ups
+
+- Sync installed skills after merge.
+"""
+        errors = validate_body(body, self.template)
+        self.assertIn("Linked Issue section must contain a `Closes #<issue>` reference.", errors)
+
+    def test_rejects_unresolved_placeholders(self) -> None:
+        body = """## Summary
+
+{{SUMMARY}}
+
+## Why
+
+This makes template structure a real CI requirement.
+
+## Linked Issue
+
+Closes #8
+
+## Verification
+
+- Local: `python scripts/validate_all.py`
+- Browser: not applicable
+- Browser evidence: not applicable
+- CI: pending after PR creation
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: yes, once required checks pass.
+
+## Blueprint Updates
+
+No blueprint updates required.
+
+## Risks / Rollback
+
+Rollback: revert this PR.
+
+## Follow-ups
+
+- Sync installed skills after merge.
+"""
+        errors = validate_body(body, self.template)
+        self.assertEqual(
+            errors[0],
+            "PR body contains unresolved template placeholders: {{SUMMARY}}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_pr_body.py
+++ b/tests/test_validate_pr_body.py
@@ -17,6 +17,9 @@ validate_body = MODULE.validate_body
 class ValidatePrBodyTests(unittest.TestCase):
     def setUp(self) -> None:
         self.template = REPO_ROOT / "skills" / "ora-et-labora" / "assets" / "templates" / "pr.md"
+        self.release_template = (
+            REPO_ROOT / "skills" / "ora-et-labora" / "assets" / "templates" / "release-pr.md"
+        )
 
     def test_accepts_valid_body(self) -> None:
         body = """## Summary
@@ -54,7 +57,34 @@ Rollback: revert this PR.
 
 - Sync installed skills after merge.
 """
-        self.assertEqual(validate_body(body, self.template), [])
+        self.assertEqual(validate_body(body, self.template, mode="implementation"), [])
+
+    def test_accepts_valid_release_body(self) -> None:
+        body = """## Release Scope
+
+- Promote workflow enforcement changes from dev to main.
+
+## Included PRs
+
+- #5
+- #7
+
+## Release Checks
+
+- Regression: local validate passed
+- Browser verification: not applicable
+- CI status: pending after PR creation
+- Migrations / schema: not applicable
+
+## Notes
+
+- Workflow-only release.
+
+## Rollback
+
+Revert the release merge commit on main if needed.
+"""
+        self.assertEqual(validate_body(body, self.release_template, mode="release"), [])
 
     def test_rejects_missing_section(self) -> None:
         body = """## Summary
@@ -88,7 +118,7 @@ Rollback: revert this PR.
 
 - Sync installed skills after merge.
 """
-        errors = validate_body(body, self.template)
+        errors = validate_body(body, self.template, mode="implementation")
         self.assertIn("Missing required section header: ## Why", errors)
 
     def test_rejects_missing_closes_reference(self) -> None:
@@ -127,7 +157,7 @@ Rollback: revert this PR.
 
 - Sync installed skills after merge.
 """
-        errors = validate_body(body, self.template)
+        errors = validate_body(body, self.template, mode="implementation")
         self.assertIn("Linked Issue section must contain a `Closes #<issue>` reference.", errors)
 
     def test_rejects_unresolved_placeholders(self) -> None:
@@ -166,10 +196,39 @@ Rollback: revert this PR.
 
 - Sync installed skills after merge.
 """
-        errors = validate_body(body, self.template)
+        errors = validate_body(body, self.template, mode="implementation")
         self.assertEqual(
             errors[0],
             "PR body contains unresolved template placeholders: {{SUMMARY}}",
+        )
+
+    def test_rejects_release_body_missing_release_checks_prefix(self) -> None:
+        body = """## Release Scope
+
+- Promote workflow enforcement changes from dev to main.
+
+## Included PRs
+
+- #5
+
+## Release Checks
+
+- Regression: local validate passed
+- Browser verification: not applicable
+- CI status: pending after PR creation
+
+## Notes
+
+- Workflow-only release.
+
+## Rollback
+
+Revert the release merge commit on main if needed.
+"""
+        errors = validate_body(body, self.release_template, mode="release")
+        self.assertIn(
+            "Release Checks section is missing required line prefix: - Migrations / schema:",
+            errors,
         )
 
 


### PR DESCRIPTION
## Release Scope

- Promote the current Ora et Labora workflow hardening from dev to stable main.
- This train is workflow-only: no application runtime, schema, or frontend behavior changes are included.
- Stable outcomes in this release are enforced issue/PR templating, PR-body CI validation, and propagation of that validator into the shipped skill and bootstrap payload.

## Included PRs

- [#5](https://github.com/emmepra/ora-et-labora/pull/5) Define safe agent auto-merge policy
- [#7](https://github.com/emmepra/ora-et-labora/pull/7) Harden issue and PR template enforcement
- [#9](https://github.com/emmepra/ora-et-labora/pull/9) Enforce PR body structure in CI
- [#11](https://github.com/emmepra/ora-et-labora/pull/11) Propagate PR body validation through bootstrap assets

## Release Checks

- Regression: Local python scripts/validate_all.py passes on current dev; suite tests and skill validation are green.
- Browser verification: Not applicable; this train contains workflow/docs/script changes only and no frontend-visible behavior.
- CI status: GitHub Validate passed on dev head 6343506 (run 24882588398). Release PR checks are pending until this PR opens.
- Migrations / schema: Not applicable; no schema, persistence, or deployment migrations are included.

## Notes

- The train makes template wrappers and GitHub issue config part of the stable workflow.
- PR bodies are now validated in CI for required structure and Closes #<issue> linkage.
- Bootstrapped repos now inherit the validator and standalone validate-pr-body workflow asset.
- Installed local skills should be resynced from main after merge.

## Rollback

Revert the release merge commit on main if rollback is needed. No migrations or irreversible data changes are included. After reverting, resync installed skills from the restored main branch so local Codex matches stable state.
