### PR TITLE
Support release PR bodies in validation gate

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,6 +27,7 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           PR_BODY: ${{ github.event.pull_request.body || '' }}
-        run: python skills/ora-et-labora/scripts/validate_pr_body.py --body "$PR_BODY"
+          BASE_BRANCH: ${{ github.base_ref || '' }}
+        run: python skills/ora-et-labora/scripts/validate_pr_body.py --body "$PR_BODY" --base-branch "$BASE_BRANCH"
       - name: Validate suite
         run: python scripts/validate_all.py

--- a/.project/logs/13.md
+++ b/.project/logs/13.md
@@ -1,0 +1,5 @@
+# Task Log: 13
+
+- 2026-04-24 | state:init | branch:feat/13-release-pr-validation | issue:#13 | note:Workspace initialized.
+- 2026-04-24 | verify:local-pass | command:`python scripts/validate_all.py` | note:23 tests passed and all skills validated after adding release-aware PR validation.
+- 2026-04-24 | verify:release-contract-pass | command:`python skills/ora-et-labora/scripts/validate_pr_body.py --body-file /tmp/ora-et-labora-release-2026-04-24.md --base-branch main` | note:Current release PR body shape now passes validation under release mode.

--- a/.project/todo/13/00_brainstorm.md
+++ b/.project/todo/13/00_brainstorm.md
@@ -1,0 +1,41 @@
+# Support release PR bodies in validation gate: Brainstorm
+
+- Date: 2026-04-24
+- Issue: [#13](https://github.com/emmepra/ora-et-labora/issues/13)
+- Kind: feature
+- Module: 13
+
+## Problem
+
+- 
+
+## Desired Outcome
+
+- 
+
+## Constraints
+
+- 
+
+## Blueprint Fit Check
+
+- Relevant blueprint docs:
+- Feasibility:
+- Conflicts or missing decisions:
+
+## Options Considered
+
+- Option A:
+- Option B:
+
+## Chosen Direction
+
+- 
+
+## Risks / Unknowns
+
+- 
+
+## Acceptance Checks
+
+- 

--- a/.project/todo/13/CURRENT.md
+++ b/.project/todo/13/CURRENT.md
@@ -1,0 +1,14 @@
+# Current State
+
+- Issue: [#13](https://github.com/emmepra/ora-et-labora/issues/13)
+- Title: Support release PR bodies in validation gate
+- Kind: feature
+- Module: 13
+- Branch: feat/13-release-pr-validation
+- Status: implementation complete; ready to open PR
+- PR: pending
+- Last verification: `python scripts/validate_all.py` passed; `python skills/ora-et-labora/scripts/validate_pr_body.py --body-file /tmp/ora-et-labora-release-2026-04-24.md --base-branch main` passed
+- Browser evidence: not applicable
+- Next step: commit, push, and open the PR to `dev`; then enable auto-merge once required checks are pending/passing
+- Blockers: none
+- Files touched: `.github/workflows/validate.yml`, `README.md`, `skills/ora-et-labora/assets/bootstrap/.github/workflows/validate-pr-body.yml`, `skills/ora-et-labora/scripts/validate_pr_body.py`, `skills/release-train/SKILL.md`, `tests/test_bootstrap_repo_templates.py`, `tests/test_template_enforcement_policy.py`, `tests/test_validate_pr_body.py`

--- a/.project/todo/13/pr.md
+++ b/.project/todo/13/pr.md
@@ -1,0 +1,43 @@
+## Summary
+
+- Makes the PR-body validator distinguish implementation PRs from release PRs.
+- Passes the PR base branch into both repo-local and bootstrapped validation workflows.
+- Adds release-path tests and documents that release PRs keep the release template instead of being forced into the implementation PR shape.
+
+## Why
+
+The active `dev` -> `main` release PR failed immediately because the validator enforced only the implementation PR template. Release PRs use a different template by design, so the gate needed to become release-aware without weakening implementation PR checks.
+
+## Linked Issue
+
+Closes #13
+
+## Verification
+
+- Local: `python scripts/validate_all.py`; `python skills/ora-et-labora/scripts/validate_pr_body.py --body-file /tmp/ora-et-labora-release-2026-04-24.md --base-branch main`
+- Browser: not applicable; workflow/docs/script-only change.
+- Browser evidence: not applicable.
+- CI: pending after PR creation.
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: yes, once required checks pass.
+- This is an implementation PR targeting `dev`.
+- Branch is rebased on `origin/dev`.
+- Browser verification is not applicable.
+- Branch-local `.project` state is current.
+
+## Blueprint Updates
+
+No blueprint files changed. This fixes a mismatch between the stable release flow and the PR-body enforcement gate.
+
+## Risks / Rollback
+
+Risk: if mode selection regresses, release PRs could fail again or implementation PRs could accidentally become too permissive.
+
+Rollback: revert this PR to restore the previous validator behavior, then manually relax the release gate until a corrected follow-up lands.
+
+## Follow-ups
+
+- After merge, recheck release PR #12 and merge it once green.
+- After the release lands on `main`, resync installed local skills from stable.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The suite includes:
 - issue, PR, release, brainstorm, current-state, and log templates
 - bootstrap assets for `.github/` and `.project/blueprint/`
 - helper scripts for template rendering, issue/PR creation, issue workspace initialization, visibility-aware bootstrap, and Playwright artifact collection
-- a CI gate that rejects malformed PR bodies that do not satisfy the suite PR template contract
+- a CI gate that rejects malformed implementation or release PR bodies that do not satisfy the suite contract
 
 The operating procedure is intentionally inline in the skill files. Extra files are reserved for templates, scripts, bootstrap assets, tests, and examples.
 

--- a/skills/ora-et-labora/assets/bootstrap/.github/workflows/validate-pr-body.yml
+++ b/skills/ora-et-labora/assets/bootstrap/.github/workflows/validate-pr-body.yml
@@ -17,4 +17,5 @@ jobs:
       - name: Validate PR body
         env:
           PR_BODY: ${{ github.event.pull_request.body || '' }}
-        run: python scripts/validate_pr_body.py --body "$PR_BODY"
+          BASE_BRANCH: ${{ github.base_ref || '' }}
+        run: python scripts/validate_pr_body.py --body "$PR_BODY" --base-branch "$BASE_BRANCH"

--- a/skills/ora-et-labora/scripts/validate_pr_body.py
+++ b/skills/ora-et-labora/scripts/validate_pr_body.py
@@ -17,6 +17,19 @@ REQUIRED_VERIFICATION_PREFIXES = (
     "- Browser evidence:",
     "- CI:",
 )
+REQUIRED_RELEASE_CHECK_PREFIXES = (
+    "- Regression:",
+    "- Browser verification:",
+    "- CI status:",
+    "- Migrations / schema:",
+)
+RELEASE_REQUIRED_HEADERS = (
+    "## Release Scope",
+    "## Included PRs",
+    "## Release Checks",
+    "## Notes",
+    "## Rollback",
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -24,6 +37,7 @@ def parse_args() -> argparse.Namespace:
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--body-file", type=Path)
     group.add_argument("--body")
+    parser.add_argument("--base-branch", default="")
     parser.add_argument("--template", type=Path)
     return parser.parse_args()
 
@@ -58,7 +72,12 @@ def extract_sections(body: str) -> dict[str, str]:
     return sections
 
 
-def validate_body(body: str, template_path: Path) -> list[str]:
+def validate_body(
+    body: str,
+    template_path: Optional[Path],
+    *,
+    mode: str = "implementation",
+) -> list[str]:
     errors: list[str] = []
 
     placeholders = sorted(set(PLACEHOLDER_RE.findall(body)))
@@ -68,7 +87,13 @@ def validate_body(body: str, template_path: Path) -> list[str]:
         )
 
     sections = extract_sections(body)
-    required_headers = load_required_headers(template_path)
+    if template_path is not None:
+        required_headers = load_required_headers(template_path)
+    elif mode == "release":
+        required_headers = list(RELEASE_REQUIRED_HEADERS)
+    else:
+        raise ValueError("template_path is required for implementation PR validation")
+
     for header in required_headers:
         if header not in sections:
             errors.append(f"Missing required section header: {header}")
@@ -76,19 +101,25 @@ def validate_body(body: str, template_path: Path) -> list[str]:
         if not sections[header]:
             errors.append(f"Section is empty: {header}")
 
-    linked_issue = sections.get("## Linked Issue", "")
-    if linked_issue and not re.search(r"(?im)\bcloses\s+#\d+\b", linked_issue):
-        errors.append("Linked Issue section must contain a `Closes #<issue>` reference.")
+    if mode == "implementation":
+        linked_issue = sections.get("## Linked Issue", "")
+        if linked_issue and not re.search(r"(?im)\bcloses\s+#\d+\b", linked_issue):
+            errors.append("Linked Issue section must contain a `Closes #<issue>` reference.")
 
-    verification = sections.get("## Verification", "")
-    for prefix in REQUIRED_VERIFICATION_PREFIXES:
-        if verification and prefix not in verification:
-            errors.append(f"Verification section is missing required line prefix: {prefix}")
+        verification = sections.get("## Verification", "")
+        for prefix in REQUIRED_VERIFICATION_PREFIXES:
+            if verification and prefix not in verification:
+                errors.append(f"Verification section is missing required line prefix: {prefix}")
+    else:
+        release_checks = sections.get("## Release Checks", "")
+        for prefix in REQUIRED_RELEASE_CHECK_PREFIXES:
+            if release_checks and prefix not in release_checks:
+                errors.append(f"Release Checks section is missing required line prefix: {prefix}")
 
     return errors
 
 
-def default_template_path(script_path: Path) -> Path:
+def default_implementation_template_path(script_path: Path) -> Path:
     candidates = [
         script_path.resolve().parents[1] / "assets" / "templates" / "pr.md",
         script_path.resolve().parents[1] / ".github" / "PULL_REQUEST_TEMPLATE.md",
@@ -102,17 +133,43 @@ def default_template_path(script_path: Path) -> Path:
     )
 
 
+def default_release_template_path(script_path: Path) -> Optional[Path]:
+    candidates = [
+        script_path.resolve().parents[1] / "assets" / "templates" / "release-pr.md",
+        script_path.resolve().parents[1] / ".github" / "release-pr.md",
+        script_path.resolve().parents[2] / ".github" / "release-pr.md",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def resolve_mode(base_branch: str, body: str) -> str:
+    if base_branch == "main":
+        return "release"
+    if "## Release Scope" in body and "## Release Checks" in body:
+        return "release"
+    return "implementation"
+
+
 def main() -> int:
     args = parse_args()
-    template_path = args.template or default_template_path(Path(__file__))
     body = load_body(args)
-    errors = validate_body(body, template_path)
+    mode = resolve_mode(args.base_branch.strip(), body)
+    if args.template is not None:
+        template_path = args.template
+    elif mode == "release":
+        template_path = default_release_template_path(Path(__file__))
+    else:
+        template_path = default_implementation_template_path(Path(__file__))
+    errors = validate_body(body, template_path, mode=mode)
     if errors:
         for error in errors:
             print(f"ERROR: {error}", file=sys.stderr)
         return 1
 
-    print("PR body matches the Ora et Labora template contract.")
+    print(f"PR body matches the Ora et Labora {mode} PR contract.")
     return 0
 
 

--- a/skills/release-train/SKILL.md
+++ b/skills/release-train/SKILL.md
@@ -91,6 +91,7 @@ Do not merge every feature/fix PR directly into `main`. That defeats grouped rel
 5. Prepare release PR body.
    - Use `../ora-et-labora/assets/templates/release-pr.md`.
    - Prefer a body file and `gh pr create --body-file <file>`.
+   - The PR-body validation gate accepts the release template shape for PRs targeting `main`; do not rewrite release PRs into the implementation template just to satisfy CI.
    - Do not assemble complex markdown inline in shell strings.
 6. Open or update the release PR.
    - Base: `main`.

--- a/tests/test_bootstrap_repo_templates.py
+++ b/tests/test_bootstrap_repo_templates.py
@@ -90,6 +90,45 @@ Revert the bootstrap if needed.
                 cwd=repo_root,
             )
 
+            release_body = repo_root / "release-body.md"
+            release_body.write_text(
+                """## Release Scope
+
+- Promote a workflow-only release to main.
+
+## Included PRs
+
+- #1
+
+## Release Checks
+
+- Regression: smoke
+- Browser verification: not applicable
+- CI status: pending
+- Migrations / schema: not applicable
+
+## Notes
+
+- Workflow-only release.
+
+## Rollback
+
+Revert the release merge commit on main if needed.
+"""
+            )
+            subprocess.run(
+                [
+                    "python",
+                    str(repo_root / "scripts" / "validate_pr_body.py"),
+                    "--body-file",
+                    str(release_body),
+                    "--base-branch",
+                    "main",
+                ],
+                check=True,
+                cwd=repo_root,
+            )
+
     def test_public_visibility_keeps_project_state_local(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)

--- a/tests/test_template_enforcement_policy.py
+++ b/tests/test_template_enforcement_policy.py
@@ -35,6 +35,7 @@ class TemplateEnforcementPolicyTests(unittest.TestCase):
         workflow = (REPO_ROOT / ".github" / "workflows" / "validate.yml").read_text()
         self.assertIn("Validate PR body", workflow)
         self.assertIn("skills/ora-et-labora/scripts/validate_pr_body.py", workflow)
+        self.assertIn("--base-branch \"$BASE_BRANCH\"", workflow)
 
     def test_skill_contains_pr_body_validator(self) -> None:
         validator = (REPO_ROOT / "skills" / "ora-et-labora" / "scripts" / "validate_pr_body.py")

--- a/tests/test_validate_pr_body.py
+++ b/tests/test_validate_pr_body.py
@@ -17,6 +17,9 @@ validate_body = MODULE.validate_body
 class ValidatePrBodyTests(unittest.TestCase):
     def setUp(self) -> None:
         self.template = REPO_ROOT / "skills" / "ora-et-labora" / "assets" / "templates" / "pr.md"
+        self.release_template = (
+            REPO_ROOT / "skills" / "ora-et-labora" / "assets" / "templates" / "release-pr.md"
+        )
 
     def test_accepts_valid_body(self) -> None:
         body = """## Summary
@@ -54,7 +57,34 @@ Rollback: revert this PR.
 
 - Sync installed skills after merge.
 """
-        self.assertEqual(validate_body(body, self.template), [])
+        self.assertEqual(validate_body(body, self.template, mode="implementation"), [])
+
+    def test_accepts_valid_release_body(self) -> None:
+        body = """## Release Scope
+
+- Promote workflow enforcement changes from dev to main.
+
+## Included PRs
+
+- #5
+- #7
+
+## Release Checks
+
+- Regression: local validate passed
+- Browser verification: not applicable
+- CI status: pending after PR creation
+- Migrations / schema: not applicable
+
+## Notes
+
+- Workflow-only release.
+
+## Rollback
+
+Revert the release merge commit on main if needed.
+"""
+        self.assertEqual(validate_body(body, self.release_template, mode="release"), [])
 
     def test_rejects_missing_section(self) -> None:
         body = """## Summary
@@ -88,7 +118,7 @@ Rollback: revert this PR.
 
 - Sync installed skills after merge.
 """
-        errors = validate_body(body, self.template)
+        errors = validate_body(body, self.template, mode="implementation")
         self.assertIn("Missing required section header: ## Why", errors)
 
     def test_rejects_missing_closes_reference(self) -> None:
@@ -127,7 +157,7 @@ Rollback: revert this PR.
 
 - Sync installed skills after merge.
 """
-        errors = validate_body(body, self.template)
+        errors = validate_body(body, self.template, mode="implementation")
         self.assertIn("Linked Issue section must contain a `Closes #<issue>` reference.", errors)
 
     def test_rejects_unresolved_placeholders(self) -> None:
@@ -166,10 +196,39 @@ Rollback: revert this PR.
 
 - Sync installed skills after merge.
 """
-        errors = validate_body(body, self.template)
+        errors = validate_body(body, self.template, mode="implementation")
         self.assertEqual(
             errors[0],
             "PR body contains unresolved template placeholders: {{SUMMARY}}",
+        )
+
+    def test_rejects_release_body_missing_release_checks_prefix(self) -> None:
+        body = """## Release Scope
+
+- Promote workflow enforcement changes from dev to main.
+
+## Included PRs
+
+- #5
+
+## Release Checks
+
+- Regression: local validate passed
+- Browser verification: not applicable
+- CI status: pending after PR creation
+
+## Notes
+
+- Workflow-only release.
+
+## Rollback
+
+Revert the release merge commit on main if needed.
+"""
+        errors = validate_body(body, self.release_template, mode="release")
+        self.assertIn(
+            "Release Checks section is missing required line prefix: - Migrations / schema:",
+            errors,
         )
 
 


### PR DESCRIPTION
## Summary

- Makes the PR-body validator distinguish implementation PRs from release PRs.
- Passes the PR base branch into both repo-local and bootstrapped validation workflows.
- Adds release-path tests and documents that release PRs keep the release template instead of being forced into the implementation PR shape.

## Why

The active `dev` -> `main` release PR failed immediately because the validator enforced only the implementation PR template. Release PRs use a different template by design, so the gate needed to become release-aware without weakening implementation PR checks.

## Linked Issue

Closes #13

## Verification

- Local: `python scripts/validate_all.py`; `python skills/ora-et-labora/scripts/validate_pr_body.py --body-file /tmp/ora-et-labora-release-2026-04-24.md --base-branch main`
- Browser: not applicable; workflow/docs/script-only change.
- Browser evidence: not applicable.
- CI: pending after PR creation.

## Auto-Merge Eligibility

- Agent auto-merge requested: yes, once required checks pass.
- This is an implementation PR targeting `dev`.
- Branch is rebased on `origin/dev`.
- Browser verification is not applicable.
- Branch-local `.project` state is current.

## Blueprint Updates

No blueprint files changed. This fixes a mismatch between the stable release flow and the PR-body enforcement gate.

## Risks / Rollback

Risk: if mode selection regresses, release PRs could fail again or implementation PRs could accidentally become too permissive.

Rollback: revert this PR to restore the previous validator behavior, then manually relax the release gate until a corrected follow-up lands.

## Follow-ups

- After merge, recheck release PR #12 and merge it once green.
- After the release lands on `main`, resync installed local skills from stable.
