### PR TITLE
Add repo governance automation

### DIFF
--- a/.project/logs/15.md
+++ b/.project/logs/15.md
@@ -1,0 +1,5 @@
+# Task Log: 15
+
+- 2026-04-24 | state:init | branch:feat/15-repo-governance-automation | issue:#15 | note:Workspace initialized.
+- 2026-04-24 | verify:local-pass | command:`python scripts/validate_all.py` | note:27 tests passed and all skills validated after adding governance automation.
+- 2026-04-24 | verify:dry-run-pass | command:`python skills/ora-et-labora/scripts/configure_repo_governance.py --repo emmepra/ora-et-labora` | note:Dry-run plan includes default branch, merge settings, and standard issue labels.

--- a/.project/todo/15/00_brainstorm.md
+++ b/.project/todo/15/00_brainstorm.md
@@ -1,0 +1,41 @@
+# Automate repo governance defaults and issue labels: Brainstorm
+
+- Date: 2026-04-24
+- Issue: [#15](https://github.com/emmepra/ora-et-labora/issues/15)
+- Kind: feature
+- Module: 15
+
+## Problem
+
+- 
+
+## Desired Outcome
+
+- 
+
+## Constraints
+
+- 
+
+## Blueprint Fit Check
+
+- Relevant blueprint docs:
+- Feasibility:
+- Conflicts or missing decisions:
+
+## Options Considered
+
+- Option A:
+- Option B:
+
+## Chosen Direction
+
+- 
+
+## Risks / Unknowns
+
+- 
+
+## Acceptance Checks
+
+- 

--- a/.project/todo/15/CURRENT.md
+++ b/.project/todo/15/CURRENT.md
@@ -1,0 +1,14 @@
+# Current State
+
+- Issue: [#15](https://github.com/emmepra/ora-et-labora/issues/15)
+- Title: Automate repo governance defaults and issue labels
+- Kind: feature
+- Module: 15
+- Branch: feat/15-repo-governance-automation
+- Status: implementation complete; ready to open PR
+- PR: pending
+- Last verification: `python scripts/validate_all.py` passed; `python skills/ora-et-labora/scripts/configure_repo_governance.py --repo emmepra/ora-et-labora` produced the expected dry-run plan
+- Browser evidence: not applicable
+- Next step: commit, push, and open the PR to `dev`; then enable auto-merge once required checks are pending/passing
+- Blockers: none
+- Files touched: `README.md`, `scripts/configure_repo_governance.py`, `skills/ora-et-labora/SKILL.md`, `skills/ora-et-labora/scripts/configure_repo_governance.py`, `skills/repo-init/SKILL.md`, `skills/repo-bootstrap/SKILL.md`, `tests/test_configure_repo_governance.py`, `tests/test_template_enforcement_policy.py`

--- a/.project/todo/15/pr.md
+++ b/.project/todo/15/pr.md
@@ -1,0 +1,43 @@
+## Summary
+
+- Adds a governance helper that can dry-run or apply standard GitHub repo settings and a default Ora et Labora issue label set.
+- Adds a repo-local wrapper plus tests for command planning and label coverage.
+- Updates `repo-init`, `repo-bootstrap`, and suite docs to use the governance helper as the standard path for repo defaults.
+
+## Why
+
+Ora et Labora documented the target GitHub state well, but still left too much of it as a manual pending step. This first automation slice turns repo defaults and standard issue labels into an executable path without overreaching into full ruleset orchestration yet.
+
+## Linked Issue
+
+Closes #15
+
+## Verification
+
+- Local: `python scripts/validate_all.py`; `python skills/ora-et-labora/scripts/configure_repo_governance.py --repo emmepra/ora-et-labora`
+- Browser: not applicable; workflow/docs/script-only change.
+- Browser evidence: not applicable.
+- CI: pending after PR creation.
+
+## Auto-Merge Eligibility
+
+- Agent auto-merge requested: yes, once required checks pass.
+- This is an implementation PR targeting `dev`.
+- Branch is rebased on `origin/dev`.
+- Browser verification is not applicable.
+- Branch-local `.project` state is current.
+
+## Blueprint Updates
+
+No blueprint files changed. This adds execution capability to the repo-init/bootstrap surfaces already defined by the suite.
+
+## Risks / Rollback
+
+Risk: the governance defaults may be too opinionated for some repos if applied blindly, which is why the helper defaults to dry-run planning and keeps full rulesets out of this first slice.
+
+Rollback: revert this PR to return governance changes to manual-only handling.
+
+## Follow-ups
+
+- Next roadmap slice should add task/worktree cleanup after merge.
+- A later slice can extend governance automation into rulesets and branch protections once repo-specific required-check handling is explicit.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The suite includes:
 - issue, PR, release, brainstorm, current-state, and log templates
 - bootstrap assets for `.github/` and `.project/blueprint/`
 - helper scripts for template rendering, issue/PR creation, issue workspace initialization, visibility-aware bootstrap, and Playwright artifact collection
+- a governance helper that can plan or apply default repo settings and a standard issue label set
 - a CI gate that rejects malformed implementation or release PR bodies that do not satisfy the suite contract
 
 The operating procedure is intentionally inline in the skill files. Extra files are reserved for templates, scripts, bootstrap assets, tests, and examples.

--- a/scripts/configure_repo_governance.py
+++ b/scripts/configure_repo_governance.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Convenience wrapper for the skill-owned repo governance helper."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "ora-et-labora"
+    / "scripts"
+    / "configure_repo_governance.py"
+)
+SPEC = importlib.util.spec_from_file_location("ora_configure_repo_governance", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC is not None and SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+if __name__ == "__main__":
+    raise SystemExit(MODULE.main())

--- a/skills/ora-et-labora/SKILL.md
+++ b/skills/ora-et-labora/SKILL.md
@@ -219,6 +219,7 @@ Scripts live under `scripts/`:
 - `render_template.py`: render markdown templates with strict placeholder replacement.
 - `create_issue_from_template.py`: render an issue template and create the GitHub issue from the body file.
 - `create_pr_from_template.py`: render a PR template and create the GitHub PR from the body file.
+- `configure_repo_governance.py`: plan or apply default GitHub repo settings and a standard Ora et Labora issue label set.
 - `validate_pr_body.py`: validate a PR body against the Ora et Labora PR template contract.
 - `init_issue_workspace.py`: initialize `00_brainstorm.md`, `CURRENT.md`, and task log.
 - `bootstrap_repo_templates.py`: copy GitHub templates, blueprint docs, the standalone PR-body workflow, and workflow examples into a target repo.

--- a/skills/ora-et-labora/scripts/configure_repo_governance.py
+++ b/skills/ora-et-labora/scripts/configure_repo_governance.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Plan or apply standard GitHub repo governance for Ora et Labora repos."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+DEFAULT_LABELS = (
+    {"name": "bug", "color": "d73a4a", "description": "Something is broken or behaves incorrectly."},
+    {"name": "enhancement", "color": "a2eeef", "description": "New feature or capability."},
+    {"name": "chore", "color": "cfd3d7", "description": "Maintenance or workflow upkeep."},
+    {"name": "docs", "color": "0075ca", "description": "Documentation-only change or request."},
+    {"name": "release", "color": "5319e7", "description": "Release train, promotion, or rollout work."},
+    {"name": "blocked", "color": "b60205", "description": "Cannot proceed until an external blocker is cleared."},
+    {"name": "hold", "color": "fbca04", "description": "Explicitly paused or waiting for user decision."},
+    {
+        "name": "needs-verification",
+        "color": "1d76db",
+        "description": "Implementation exists but required verification evidence is still missing.",
+    },
+)
+
+
+@dataclass(frozen=True)
+class GovernanceSettings:
+    repo: str
+    default_branch: str
+    stable_branch: str
+    delete_branch_on_merge: bool
+    enable_auto_merge: bool
+    allow_update_branch: bool
+    enable_merge_commit: bool
+    enable_squash_merge: bool
+    enable_rebase_merge: bool
+    include_settings: bool
+    include_labels: bool
+    apply: bool
+
+
+def parse_args() -> GovernanceSettings:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="GitHub repository in OWNER/REPO form.")
+    parser.add_argument("--default-branch", default="dev")
+    parser.add_argument("--stable-branch", default="main")
+    parser.add_argument("--skip-settings", action="store_true")
+    parser.add_argument("--skip-labels", action="store_true")
+    parser.add_argument("--apply", action="store_true", help="Execute commands instead of printing the plan.")
+
+    parser.add_argument(
+        "--delete-branch-on-merge",
+        dest="delete_branch_on_merge",
+        action="store_true",
+        default=True,
+    )
+    parser.add_argument(
+        "--keep-branch-on-merge",
+        dest="delete_branch_on_merge",
+        action="store_false",
+    )
+    parser.add_argument(
+        "--enable-auto-merge",
+        dest="enable_auto_merge",
+        action="store_true",
+        default=True,
+    )
+    parser.add_argument(
+        "--disable-auto-merge",
+        dest="enable_auto_merge",
+        action="store_false",
+    )
+    parser.add_argument(
+        "--allow-update-branch",
+        dest="allow_update_branch",
+        action="store_true",
+        default=True,
+    )
+    parser.add_argument(
+        "--disallow-update-branch",
+        dest="allow_update_branch",
+        action="store_false",
+    )
+    parser.add_argument(
+        "--enable-merge-commit",
+        dest="enable_merge_commit",
+        action="store_true",
+        default=True,
+    )
+    parser.add_argument(
+        "--disable-merge-commit",
+        dest="enable_merge_commit",
+        action="store_false",
+    )
+    parser.add_argument(
+        "--enable-squash-merge",
+        dest="enable_squash_merge",
+        action="store_true",
+        default=True,
+    )
+    parser.add_argument(
+        "--disable-squash-merge",
+        dest="enable_squash_merge",
+        action="store_false",
+    )
+    parser.add_argument(
+        "--enable-rebase-merge",
+        dest="enable_rebase_merge",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--disable-rebase-merge",
+        dest="enable_rebase_merge",
+        action="store_false",
+    )
+
+    args = parser.parse_args()
+    return GovernanceSettings(
+        repo=args.repo,
+        default_branch=args.default_branch,
+        stable_branch=args.stable_branch,
+        delete_branch_on_merge=args.delete_branch_on_merge,
+        enable_auto_merge=args.enable_auto_merge,
+        allow_update_branch=args.allow_update_branch,
+        enable_merge_commit=args.enable_merge_commit,
+        enable_squash_merge=args.enable_squash_merge,
+        enable_rebase_merge=args.enable_rebase_merge,
+        include_settings=not args.skip_settings,
+        include_labels=not args.skip_labels,
+        apply=args.apply,
+    )
+
+
+def append_toggle(cmd: list[str], flag: str, enabled: bool) -> None:
+    cmd.append(flag if enabled else f"{flag}=false")
+
+
+def build_repo_edit_command(settings: GovernanceSettings) -> list[str]:
+    cmd = ["gh", "repo", "edit", settings.repo, "--default-branch", settings.default_branch]
+    append_toggle(cmd, "--delete-branch-on-merge", settings.delete_branch_on_merge)
+    append_toggle(cmd, "--enable-auto-merge", settings.enable_auto_merge)
+    append_toggle(cmd, "--allow-update-branch", settings.allow_update_branch)
+    append_toggle(cmd, "--enable-merge-commit", settings.enable_merge_commit)
+    append_toggle(cmd, "--enable-squash-merge", settings.enable_squash_merge)
+    append_toggle(cmd, "--enable-rebase-merge", settings.enable_rebase_merge)
+    return cmd
+
+
+def build_label_command(repo: str, label: dict[str, str]) -> list[str]:
+    return [
+        "gh",
+        "label",
+        "create",
+        label["name"],
+        "--repo",
+        repo,
+        "--color",
+        label["color"],
+        "--description",
+        label["description"],
+        "--force",
+    ]
+
+
+def build_commands(settings: GovernanceSettings) -> list[list[str]]:
+    commands: list[list[str]] = []
+    if settings.include_settings:
+        commands.append(build_repo_edit_command(settings))
+    if settings.include_labels:
+        commands.extend(build_label_command(settings.repo, label) for label in DEFAULT_LABELS)
+    return commands
+
+
+def format_plan(settings: GovernanceSettings) -> str:
+    lines = [
+        f"Governance plan for {settings.repo}",
+        f"- default branch: {settings.default_branch}",
+        f"- stable branch (expected): {settings.stable_branch}",
+        f"- repo settings: {'apply' if settings.include_settings else 'skip'}",
+        f"- default labels: {'apply' if settings.include_labels else 'skip'}",
+        "- branch protections/rulesets: pending by design; handled in a later automation slice",
+        "",
+    ]
+    for cmd in build_commands(settings):
+        lines.append("$ " + shlex.join(cmd))
+    return "\n".join(lines) + "\n"
+
+
+def run_commands(commands: list[list[str]]) -> None:
+    for cmd in commands:
+        subprocess.run(cmd, check=True)
+
+
+def main() -> int:
+    settings = parse_args()
+    commands = build_commands(settings)
+    if not settings.apply:
+        sys.stdout.write(format_plan(settings))
+        return 0
+
+    run_commands(commands)
+    print(f"Applied Ora et Labora governance defaults to {settings.repo}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/repo-bootstrap/SKILL.md
+++ b/skills/repo-bootstrap/SKILL.md
@@ -57,6 +57,7 @@ Do not use this skill when:
 | PR template | `.github/PULL_REQUEST_TEMPLATE.md` with a `Linked Issue` / `Closes #` section |
 | PR body validation workflow | `.github/workflows/validate-pr-body.yml` |
 | PR body validator script | `scripts/validate_pr_body.py` |
+| Governance helper | `../ora-et-labora/scripts/configure_repo_governance.py` |
 | CI placeholder | `.github/workflows/ci.yml.example` |
 | Release placeholder | `.github/workflows/release.yml.example` |
 | Workflow blueprint | `.project/blueprint/00_workflow.md` |
@@ -123,6 +124,7 @@ Private/internal profile rule: `.project/` may be versioned, but raw browser art
    - Ensure `dev` exists.
    - Ensure `main` exists.
    - Set default branch to `dev`.
+   - Apply the standard repo settings and default label set with `configure_repo_governance.py` when appropriate.
    - Configure branch protections or rulesets if requested and supported.
 7. Validate.
    - Check generated markdown formatting.
@@ -147,6 +149,13 @@ Typical CLI operations after the remote exists:
 
 ```bash
 gh repo edit OWNER/REPO --default-branch dev
+```
+
+Preferred governance path after the remote exists:
+
+```bash
+python skills/ora-et-labora/scripts/configure_repo_governance.py --repo OWNER/REPO
+python skills/ora-et-labora/scripts/configure_repo_governance.py --repo OWNER/REPO --apply
 ```
 
 Branch protection and rulesets may require `gh api` or repository settings automation. Do not pretend they were configured if only templates were copied.

--- a/skills/repo-init/SKILL.md
+++ b/skills/repo-init/SKILL.md
@@ -186,6 +186,7 @@ Do not create the GitHub repo before this approval.
    - For `public` repos, keep `.project/` local by default and translate stable guidance into public docs if requested.
    - Add CI/release placeholders appropriate for the repo type.
    - Apply the profile-aware `.gitignore` policy with `bootstrap_repo_templates.py --visibility <profile>`.
+   - Plan or apply the standard repo settings and label bundle with `configure_repo_governance.py`.
    - Keep placeholders clearly marked until project-specific commands are known.
 8. Commit and push initial setup if approved.
    - Keep initial commit scoped to repo initialization.
@@ -224,6 +225,18 @@ Set default branch after `dev` exists remotely:
 
 ```bash
 gh repo edit OWNER/REPO --default-branch dev
+```
+
+Plan the standard governance changes first:
+
+```bash
+python skills/ora-et-labora/scripts/configure_repo_governance.py --repo OWNER/REPO
+```
+
+Apply them explicitly after approval:
+
+```bash
+python skills/ora-et-labora/scripts/configure_repo_governance.py --repo OWNER/REPO --apply
 ```
 
 Do not claim branch protection or rulesets are configured unless the command/API call has actually succeeded.
@@ -294,6 +307,17 @@ If not configured:
 
 - record as pending
 - do not imply protection exists
+
+The current governance helper covers:
+
+- default branch
+- delete branch on merge
+- auto-merge enablement
+- update-branch allowance
+- merge/squash/rebase merge method toggles
+- a default issue label set including `bug`, `enhancement`, `chore`, `docs`, and `release`
+
+Branch protection and rulesets should still be reported as pending unless separately configured.
 
 ## Red Flags - Stop Before Creating
 

--- a/tests/test_configure_repo_governance.py
+++ b/tests/test_configure_repo_governance.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "skills" / "ora-et-labora" / "scripts" / "configure_repo_governance.py"
+SPEC = importlib.util.spec_from_file_location("configure_repo_governance", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC is not None and SPEC.loader is not None
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class ConfigureRepoGovernanceTests(unittest.TestCase):
+    def test_build_repo_edit_command_uses_expected_defaults(self) -> None:
+        settings = MODULE.GovernanceSettings(
+            repo="owner/repo",
+            default_branch="dev",
+            stable_branch="main",
+            delete_branch_on_merge=True,
+            enable_auto_merge=True,
+            allow_update_branch=True,
+            enable_merge_commit=True,
+            enable_squash_merge=True,
+            enable_rebase_merge=False,
+            include_settings=True,
+            include_labels=True,
+            apply=False,
+        )
+        cmd = MODULE.build_repo_edit_command(settings)
+        self.assertEqual(cmd[:4], ["gh", "repo", "edit", "owner/repo"])
+        self.assertIn("--default-branch", cmd)
+        self.assertIn("--delete-branch-on-merge", cmd)
+        self.assertIn("--enable-auto-merge", cmd)
+        self.assertIn("--allow-update-branch", cmd)
+        self.assertIn("--enable-merge-commit", cmd)
+        self.assertIn("--enable-squash-merge", cmd)
+        self.assertIn("--enable-rebase-merge=false", cmd)
+
+    def test_label_bundle_contains_bug_and_enhancement(self) -> None:
+        labels = {label["name"] for label in MODULE.DEFAULT_LABELS}
+        self.assertIn("bug", labels)
+        self.assertIn("enhancement", labels)
+        self.assertIn("release", labels)
+
+    def test_dry_run_prints_plan(self) -> None:
+        result = subprocess.run(
+            [
+                "python",
+                str(SCRIPT),
+                "--repo",
+                "owner/repo",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("Governance plan for owner/repo", result.stdout)
+        self.assertIn("gh repo edit owner/repo --default-branch dev", result.stdout)
+        self.assertIn("gh label create bug --repo owner/repo", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_template_enforcement_policy.py
+++ b/tests/test_template_enforcement_policy.py
@@ -41,6 +41,12 @@ class TemplateEnforcementPolicyTests(unittest.TestCase):
         validator = (REPO_ROOT / "skills" / "ora-et-labora" / "scripts" / "validate_pr_body.py")
         self.assertTrue(validator.exists())
 
+    def test_repo_init_and_bootstrap_reference_governance_helper(self) -> None:
+        repo_init = (REPO_ROOT / "skills" / "repo-init" / "SKILL.md").read_text()
+        repo_bootstrap = (REPO_ROOT / "skills" / "repo-bootstrap" / "SKILL.md").read_text()
+        self.assertIn("configure_repo_governance.py", repo_init)
+        self.assertIn("configure_repo_governance.py", repo_bootstrap)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds a governance helper that can dry-run or apply standard GitHub repo settings and a default Ora et Labora issue label set.
- Adds a repo-local wrapper plus tests for command planning and label coverage.
- Updates `repo-init`, `repo-bootstrap`, and suite docs to use the governance helper as the standard path for repo defaults.

## Why

Ora et Labora documented the target GitHub state well, but still left too much of it as a manual pending step. This first automation slice turns repo defaults and standard issue labels into an executable path without overreaching into full ruleset orchestration yet.

## Linked Issue

Closes #15

## Verification

- Local: `python scripts/validate_all.py`; `python skills/ora-et-labora/scripts/configure_repo_governance.py --repo emmepra/ora-et-labora`
- Browser: not applicable; workflow/docs/script-only change.
- Browser evidence: not applicable.
- CI: pending after PR creation.

## Auto-Merge Eligibility

- Agent auto-merge requested: yes, once required checks pass.
- This is an implementation PR targeting `dev`.
- Branch is rebased on `origin/dev`.
- Browser verification is not applicable.
- Branch-local `.project` state is current.

## Blueprint Updates

No blueprint files changed. This adds execution capability to the repo-init/bootstrap surfaces already defined by the suite.

## Risks / Rollback

Risk: the governance defaults may be too opinionated for some repos if applied blindly, which is why the helper defaults to dry-run planning and keeps full rulesets out of this first slice.

Rollback: revert this PR to return governance changes to manual-only handling.

## Follow-ups

- Next roadmap slice should add task/worktree cleanup after merge.
- A later slice can extend governance automation into rulesets and branch protections once repo-specific required-check handling is explicit.
