### PR TITLE
Add merged-task cleanup and archive flow

### DIFF
--- a/.project/logs/17.md
+++ b/.project/logs/17.md
@@ -1,0 +1,5 @@
+# Task Log: 17
+
+- 2026-04-24 | state:init | branch:feat/17-task-cleanup-flow | issue:#17 | note:Workspace initialized.
+- 2026-04-24 | approach:change | note:Phase 2 will archive merged task workspaces under .project/logs/archive/<module-id> and clean the owning worktree/local branch through a dry-run-first helper.
+- 2026-04-24 | verify:pass | checks:python scripts/validate_all.py | note:Cleanup helper, documentation updates, and regression tests all passed.

--- a/.project/todo/17/00_brainstorm.md
+++ b/.project/todo/17/00_brainstorm.md
@@ -1,0 +1,56 @@
+# Add merged-task cleanup and archive flow: Brainstorm
+
+- Date: 2026-04-24
+- Issue: [#17](https://github.com/emmepra/ora-et-labora/issues/17)
+- Kind: feature
+- Module: 17
+
+## Problem
+
+- Ora et Labora is strong at creating issue workspaces and worktrees, but it has no standard closeout path after a PR merges into `dev`.
+- Merged task state, worktrees, and local branches can accumulate indefinitely, which weakens repo hygiene and makes the workflow heavier over time.
+- Cleanup currently depends on ad hoc manual commands, so agents may forget to archive state, remove the worktree, or retire the local branch consistently.
+
+## Desired Outcome
+
+- Provide a standard helper that plans and applies post-merge cleanup for a task workspace.
+- Keep cleanup safe by default: dry-run first, require `--apply`, and refuse destructive cleanup unless the branch is already merged into the integration branch unless explicitly forced.
+- Preserve task history by archiving the task workspace before removing the worktree and local branch.
+
+## Constraints
+
+- The cleanup flow must fit the existing Ora et Labora artifact model and branch/worktree conventions.
+- The helper must work from the repo root and use deterministic paths derived from the module ID and branch name.
+- The archive path should stay consistent with the existing preference for `.project/logs/` as the durable historical surface.
+- The flow must not delete protected branches or branches that are still active in another worktree.
+
+## Blueprint Fit Check
+
+- Relevant blueprint docs:
+  - `.project/blueprint/00_overview.md`
+  - `.project/blueprint/02_worktree-runtime.md`
+- Feasibility: fits with an additive helper plus workflow/documentation updates.
+- Conflicts or missing decisions: none; this extends the workflow after merge rather than changing integration or release policy.
+
+## Options Considered
+
+- Option A: archive task state under `.project/logs/archive/<module-id>` and leave the main task log in place.
+- Option B: introduce a separate `.project/archive/` tree for closed task workspaces.
+
+## Chosen Direction
+
+- Choose option A.
+- It keeps archival state under the existing durable-history surface, avoids adding another top-level `.project` area, and matches the user preference to keep the repo operational model tighter rather than broader.
+
+## Risks / Unknowns
+
+- Cleanup should not silently remove branches that are not actually merged.
+- Worktree removal and branch deletion should remain optional so the helper can be used in partial-cleanup scenarios.
+- The docs need to make clear that this is a post-merge cleanup step, not a substitute for PR/release verification.
+
+## Acceptance Checks
+
+- Dry-run output shows the archive, worktree removal, and branch deletion plan.
+- `--apply` archives the task workspace and removes the merged worktree and local branch.
+- The helper refuses cleanup when the branch is not merged into the target ref.
+- The suite docs point agents to the new post-merge cleanup path.

--- a/.project/todo/17/CURRENT.md
+++ b/.project/todo/17/CURRENT.md
@@ -1,0 +1,14 @@
+# Current State
+
+- Issue: [#17](https://github.com/emmepra/ora-et-labora/issues/17)
+- Title: Add merged-task cleanup and archive flow
+- Kind: feature
+- Module: 17
+- Branch: feat/17-task-cleanup-flow
+- Status: implementation in progress
+- PR: pending
+- Last verification: pass (`python scripts/validate_all.py`)
+- Browser evidence: not applicable (workflow/docs/scripts only)
+- Next step: render the PR body, open the PR to dev, and record the PR state for auto-merge
+- Blockers: none
+- Files touched: skills/ora-et-labora/scripts/close_task_workspace.py; scripts/close_task_workspace.py; tests/test_close_task_workspace.py; README.md; skills/ora-et-labora/SKILL.md; skills/state-logging/SKILL.md; skills/worktree-flow/SKILL.md; tests/test_template_enforcement_policy.py

--- a/.project/todo/17/pr.md
+++ b/.project/todo/17/pr.md
@@ -1,0 +1,39 @@
+## Summary
+
+- add `close_task_workspace.py` to archive merged task workspaces and retire the owning worktree/local branch through a dry-run-first flow
+- add regression tests for dry-run planning, apply cleanup, and unmerged-branch refusal
+- wire the cleanup flow into the README, suite index, and relevant execution skills
+
+## Why
+
+Phase 2 closes the post-merge gap in Ora et Labora. The suite could shape work and drive PRs into `dev`, but it had no standard way to archive finished task state or retire merged worktrees and local branches.
+
+## Linked Issue
+
+Closes #17
+
+## Verification
+
+- Local: `python scripts/validate_all.py`
+- Browser: Not applicable; workflow/docs/scripts only.
+- Browser evidence: Not applicable.
+- CI: Pending GitHub `validate`.
+
+## Auto-Merge Eligibility
+
+- Eligible for implementation auto-merge into `dev` after `validate` passes.
+- Branch is current with `origin/dev` before push.
+- Local verification is recorded in `.project/todo/17/CURRENT.md` and `.project/logs/17.md`.
+- Browser verification is not applicable for this workflow/docs/scripts change.
+
+## Blueprint Updates
+
+None.
+
+## Risks / Rollback
+
+Low risk and limited to workflow helpers, documentation, and regression tests. Roll back by reverting the cleanup helper, wrapper, and associated docs/tests.
+
+## Follow-ups
+
+- Continue the roadmap with the public-mode audit gate.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,11 @@ Repo creation and bootstrap are visibility-aware. Private and internal repos can
 7. Open or update the PR to `dev`.
    - summarize implementation, verification, and blueprint impact
    - include `Closes #<issue>` for the originating issue
-8. Release `dev` to `main` when requested.
+8. Clean up after merge.
+   - archive the merged task workspace under `.project/logs/archive/<module-id>/`
+   - remove the owning worktree and local branch when safe
+   - use `python scripts/close_task_workspace.py --repo-root . --module-id <module-id>` and add `--apply` only after checking the plan
+9. Release `dev` to `main` when requested.
    - grouped release PRs, not one stable merge per implementation PR
 
 ## Core Points
@@ -69,6 +73,7 @@ Repo creation and bootstrap are visibility-aware. Private and internal repos can
 - Browser verification requires evidence, not just a claim.
 - Implementation PRs must reference and close their originating issues.
 - Implementation PR auto-merge is allowed only for eligible `dev` PRs.
+- Merged task work should be archived and retired deliberately, not left as lingering worktrees.
 - Release PRs into `main` require explicit approval before merge.
 - Docker behavior across worktrees must be explicit.
 - Public repos keep agent-private state local unless explicitly sanitized.
@@ -102,6 +107,7 @@ The suite includes:
 - bootstrap assets for `.github/` and `.project/blueprint/`
 - helper scripts for template rendering, issue/PR creation, issue workspace initialization, visibility-aware bootstrap, and Playwright artifact collection
 - a governance helper that can plan or apply default repo settings and a standard issue label set
+- a cleanup helper that archives merged task workspaces and retires the owning worktree/local branch through a dry-run-first flow
 - a CI gate that rejects malformed implementation or release PR bodies that do not satisfy the suite contract
 
 The operating procedure is intentionally inline in the skill files. Extra files are reserved for templates, scripts, bootstrap assets, tests, and examples.

--- a/scripts/close_task_workspace.py
+++ b/scripts/close_task_workspace.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Convenience wrapper for the skill-owned task cleanup helper."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "ora-et-labora"
+    / "scripts"
+    / "close_task_workspace.py"
+)
+SPEC = importlib.util.spec_from_file_location("ora_close_task_workspace", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC is not None and SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+if __name__ == "__main__":
+    raise SystemExit(MODULE.main())

--- a/skills/ora-et-labora/SKILL.md
+++ b/skills/ora-et-labora/SKILL.md
@@ -63,13 +63,16 @@ Do not use this skill as a substitute for the detailed phase skills. If the task
 6. Open or update implementation PR.
    - Use `worktree-flow`, `state-logging`, and `verify-and-evidence`.
    - Render PR body from a file or template.
-7. Release.
+7. Close the merged task workspace.
+   - Use `state-logging` and `worktree-flow`.
+   - Archive the merged task todo under `.project/logs/archive/<module-id>/` and retire the owning worktree/local branch with the cleanup helper.
+8. Release.
    - Use `release-train`.
    - Promote grouped `dev` work to `main` with release checks and rollback notes.
-8. Create new repos.
+9. Create new repos.
    - Use `repo-init`.
    - Confirm owner/org, visibility, repo type, source mode, local path, and branch model before creating GitHub remotes.
-9. Bootstrap existing repos.
+10. Bootstrap existing repos.
    - Use `repo-bootstrap`.
    - Apply templates, blueprint docs, branch defaults, and GitHub setting plan to a repo that already exists.
 
@@ -101,6 +104,7 @@ Do not use this skill as a substitute for the detailed phase skills. If the task
 | `00_brainstorm.md` | challenge record, assumptions, options, risks, blueprint fit | PR status, raw command output |
 | `CURRENT.md` | current status, branch, PR, latest verification, next step, blockers | historical diary, full issue body, raw artifacts |
 | task log | meaningful deltas and state transitions | every command, every edit, repeated issue text |
+| `.project/logs/archive/<module-id>/` | archived task workspace after merge cleanup | active branch state, raw temp artifacts |
 | `.project/blueprint/` | durable project model and workflow invariants | task-local notes, transient blockers |
 | PR body | implementation summary, closing issue reference, verification evidence, risks, rollback/follow-ups | unresolved template placeholders, raw traces |
 | release PR | grouped scope, release checks, migrations, rollback | individual implementation diaries |
@@ -222,6 +226,7 @@ Scripts live under `scripts/`:
 - `configure_repo_governance.py`: plan or apply default GitHub repo settings and a standard Ora et Labora issue label set.
 - `validate_pr_body.py`: validate a PR body against the Ora et Labora PR template contract.
 - `init_issue_workspace.py`: initialize `00_brainstorm.md`, `CURRENT.md`, and task log.
+- `close_task_workspace.py`: archive a merged task workspace and retire the owning worktree/local branch through a dry-run-first cleanup flow.
 - `bootstrap_repo_templates.py`: copy GitHub templates, blueprint docs, the standalone PR-body workflow, and workflow examples into a target repo.
 - `bootstrap_repo_templates.py --visibility <profile>`: also writes the profile-aware artifact policy into `.gitignore`.
 - `collect_playwright_artifacts.py`: collect browser verification artifacts into `.project/logs/playwright/<module-id>/<run-id>/`.
@@ -258,5 +263,6 @@ For any nontrivial task, completion requires:
 - PR opened or updated against `dev`
 - PR body references and closes the originating issue
 - task state and log reflect the latest truth
+- merged task work is archived and cleaned up when the branch is complete
 
 If any item is intentionally skipped, state why.

--- a/skills/ora-et-labora/scripts/close_task_workspace.py
+++ b/skills/ora-et-labora/scripts/close_task_workspace.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Archive merged task state and clean up the owning worktree and local branch."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import shutil
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Optional
+
+
+PROTECTED_BRANCHES = {"main", "dev"}
+WORK_BRANCH_PREFIXES = ("feat/", "fix/", "chore/", "hotfix/")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--module-id", required=True)
+    parser.add_argument("--branch", help="Owning local branch. Defaults to the branch recorded in CURRENT.md.")
+    parser.add_argument(
+        "--merged-into",
+        default="origin/dev",
+        help="Target branch/ref that must already contain the task branch before cleanup.",
+    )
+    parser.add_argument(
+        "--archive-root",
+        default=".project/logs/archive",
+        help="Archive root relative to repo root.",
+    )
+    parser.add_argument("--keep-worktree", action="store_true")
+    parser.add_argument("--keep-branch", action="store_true")
+    parser.add_argument("--keep-todo", action="store_true")
+    parser.add_argument("--prune-merged-branches", action="store_true")
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    return parser.parse_args()
+
+
+def git(repo_root: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def path_for_module(repo_root: Path, module_id: str) -> tuple[Path, Path]:
+    todo_dir = repo_root / ".project" / "todo" / module_id
+    log_path = repo_root / ".project" / "logs" / f"{module_id}.md"
+    return todo_dir, log_path
+
+
+def worktree_paths_for_module(repo_root: Path, module_id: str) -> list[tuple[Path, Path]]:
+    worktrees_root = repo_root / ".project" / "worktrees"
+    if not worktrees_root.exists():
+        return []
+    matches: list[tuple[Path, Path]] = []
+    for current_path in sorted(worktrees_root.glob(f"*/.project/todo/{module_id}/CURRENT.md")):
+        todo_dir = current_path.parent
+        worktree_root = current_path.parents[3]
+        matches.append((todo_dir, worktree_root))
+    return matches
+
+
+def detect_branch(todo_dir: Path) -> Optional[str]:
+    current = todo_dir / "CURRENT.md"
+    if not current.exists():
+        return None
+    for line in current.read_text().splitlines():
+        if line.startswith("- Branch:"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def branch_exists(repo_root: Path, branch: str) -> bool:
+    result = git(repo_root, "show-ref", "--verify", f"refs/heads/{branch}", check=False)
+    return result.returncode == 0
+
+
+def ref_exists(repo_root: Path, ref: str) -> bool:
+    result = git(repo_root, "rev-parse", "--verify", ref, check=False)
+    return result.returncode == 0
+
+
+def branch_is_merged(repo_root: Path, branch: str, merged_into: str) -> bool:
+    result = git(repo_root, "merge-base", "--is-ancestor", branch, merged_into, check=False)
+    return result.returncode == 0
+
+
+def worktree_path(repo_root: Path, branch: str) -> Path:
+    return repo_root / ".project" / "worktrees" / branch.replace("/", "-")
+
+
+def current_git_branch(repo_root: Path) -> str:
+    return git(repo_root, "branch", "--show-current").stdout.strip()
+
+
+def resolve_task_state(
+    repo_root: Path,
+    module_id: str,
+    branch: Optional[str],
+) -> tuple[str, Path, Path, Path]:
+    repo_todo_dir, repo_log_path = path_for_module(repo_root, module_id)
+    if repo_todo_dir.exists():
+        detected = branch or detect_branch(repo_todo_dir)
+        if detected:
+            return detected, repo_todo_dir, repo_log_path, worktree_path(repo_root, detected)
+
+    worktree_matches = worktree_paths_for_module(repo_root, module_id)
+    if branch:
+        for todo_dir, worktree_root in worktree_matches:
+            if detect_branch(todo_dir) == branch:
+                return (
+                    branch,
+                    todo_dir,
+                    worktree_root / ".project" / "logs" / f"{module_id}.md",
+                    worktree_root,
+                )
+    else:
+        detected_matches = [
+            (detected_branch, todo_dir, worktree_root)
+            for todo_dir, worktree_root in worktree_matches
+            if (detected_branch := detect_branch(todo_dir))
+        ]
+        if len(detected_matches) == 1:
+            detected_branch, todo_dir, worktree_root = detected_matches[0]
+            return (
+                detected_branch,
+                todo_dir,
+                worktree_root / ".project" / "logs" / f"{module_id}.md",
+                worktree_root,
+            )
+        if len(detected_matches) > 1:
+            choices = ", ".join(sorted(match[0] for match in detected_matches))
+            raise SystemExit(
+                f"Multiple worktree task states found for module {module_id!r}. Pass --branch explicitly. Choices: {choices}"
+            )
+
+    raise SystemExit(
+        "Could not determine branch. Pass --branch explicitly or ensure CURRENT.md records it."
+    )
+
+
+def update_current_for_archive(current_path: Path, archive_rel: str) -> None:
+    if not current_path.exists():
+        return
+    lines = current_path.read_text().splitlines()
+    replacements = {
+        "- Status:": "- Status: merged and archived",
+        "- Next step:": "- Next step: none; cleanup complete",
+        "- Blockers:": "- Blockers: none",
+    }
+    new_lines = []
+    for line in lines:
+        replaced = False
+        for prefix, value in replacements.items():
+            if line.startswith(prefix):
+                new_lines.append(value)
+                replaced = True
+                break
+        if not replaced:
+            new_lines.append(line)
+    new_lines.append(f"- Archive: {archive_rel}")
+    current_path.write_text("\n".join(new_lines) + "\n")
+
+
+def append_log(log_path: Path, message: str) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a") as handle:
+        handle.write(message)
+
+
+def ensure_root_log(log_path: Path, source_log_path: Path, module_id: str) -> None:
+    if log_path.exists():
+        return
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    if source_log_path.exists() and source_log_path != log_path:
+        shutil.copy2(source_log_path, log_path)
+        return
+    log_path.write_text(f"# Task Log: {module_id}\n")
+
+
+def active_worktree_branches(repo_root: Path) -> set[str]:
+    result = git(repo_root, "worktree", "list", "--porcelain")
+    branches: set[str] = set()
+    for line in result.stdout.splitlines():
+        if line.startswith("branch refs/heads/"):
+            branches.add(line.removeprefix("branch refs/heads/"))
+    return branches
+
+
+def local_branches(repo_root: Path) -> list[str]:
+    result = git(repo_root, "for-each-ref", "--format=%(refname:short)", "refs/heads")
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def prune_candidates(repo_root: Path, merged_into: str, exclude: set[str]) -> list[str]:
+    candidates: list[str] = []
+    active = active_worktree_branches(repo_root)
+    for branch in local_branches(repo_root):
+        if branch in PROTECTED_BRANCHES or branch in exclude or branch in active:
+            continue
+        if not branch.startswith(WORK_BRANCH_PREFIXES):
+            continue
+        if not branch_is_merged(repo_root, branch, merged_into):
+            continue
+        candidates.append(branch)
+    return sorted(candidates)
+
+
+def plan_lines(
+    *,
+    module_id: str,
+    branch: str,
+    merged_into: str,
+    merged: bool,
+    todo_dir: Path,
+    archive_dir: Path,
+    worktree_dir: Path,
+    keep_todo: bool,
+    keep_worktree: bool,
+    keep_branch: bool,
+    prune_candidates_list: list[str],
+) -> list[str]:
+    lines = [
+        f"Cleanup plan for module {module_id}",
+        f"- branch: {branch}",
+        f"- merged into {merged_into}: {'yes' if merged else 'no'}",
+        f"- todo dir: {todo_dir}",
+        f"- archive dir: {archive_dir}",
+        f"- worktree dir: {worktree_dir}",
+        "",
+    ]
+    if not keep_todo:
+        lines.append(f"$ archive {todo_dir} -> {archive_dir}")
+    if not keep_worktree:
+        lines.append("$ " + shlex.join(["git", "worktree", "remove", str(worktree_dir)]))
+    if not keep_branch:
+        lines.append("$ " + shlex.join(["git", "branch", "-d", branch]))
+    if prune_candidates_list:
+        lines.append("")
+        lines.append("Additional merged branch prune candidates:")
+        for candidate in prune_candidates_list:
+            lines.append(f"- {candidate}")
+    return lines
+
+
+def ensure_safe_to_apply(repo_root: Path, branch: str, merged: bool, force: bool) -> None:
+    if merged or force:
+        return
+    raise SystemExit(
+        f"Refusing cleanup because branch {branch!r} is not merged into the target ref. Use --force to override."
+    )
+
+
+def remove_worktree(repo_root: Path, path: Path, force: bool) -> None:
+    if not path.exists():
+        return
+    cmd = ["worktree", "remove", str(path)]
+    if force:
+        cmd.insert(2, "--force")
+    git(repo_root, *cmd)
+
+
+def delete_branch(repo_root: Path, branch: str, force: bool) -> None:
+    if not branch_exists(repo_root, branch):
+        return
+    if current_git_branch(repo_root) == branch:
+        raise SystemExit(f"Refusing to delete currently checked out branch {branch!r}.")
+    git(repo_root, "branch", "-D" if force else "-d", branch)
+
+
+def archive_task(
+    todo_dir: Path,
+    archive_dir: Path,
+    source_log_path: Path,
+    root_log_path: Path,
+    module_id: str,
+    branch: str,
+    merged_into: str,
+    archive_rel: str,
+) -> None:
+    archive_dir.parent.mkdir(parents=True, exist_ok=True)
+    if archive_dir.exists():
+        raise SystemExit(f"Archive destination already exists: {archive_dir}")
+    current_path = todo_dir / "CURRENT.md"
+    update_current_for_archive(current_path, archive_rel)
+    shutil.move(str(todo_dir), str(archive_dir))
+    ensure_root_log(root_log_path, source_log_path, module_id)
+    append_log(
+        root_log_path,
+        f"- {date.today().isoformat()} | state:closed | branch:{branch} | merged-into:{merged_into} | archive:{archive_rel} | note:Archived task state after merge cleanup.\n",
+    )
+
+def apply_cleanup(
+    args: argparse.Namespace,
+    branch: str,
+    merged: bool,
+    source_todo_dir: Path,
+    source_log_path: Path,
+    root_log_path: Path,
+    worktree_dir: Path,
+) -> None:
+    repo_root = args.repo_root.resolve()
+    archive_dir = repo_root / args.archive_root / args.module_id
+    archive_rel = str(Path(args.archive_root) / args.module_id)
+
+    ensure_safe_to_apply(repo_root, branch, merged, args.force)
+    if not args.keep_todo:
+        archive_task(
+            source_todo_dir,
+            archive_dir,
+            source_log_path,
+            root_log_path,
+            args.module_id,
+            branch,
+            args.merged_into,
+            archive_rel,
+        )
+    if not args.keep_worktree:
+        remove_worktree(repo_root, worktree_dir, args.force)
+    if not args.keep_branch:
+        delete_branch(repo_root, branch, args.force)
+    if args.prune_merged_branches:
+        extra_candidates = prune_candidates(repo_root, args.merged_into, exclude={branch})
+        for candidate in extra_candidates:
+            delete_branch(repo_root, candidate, args.force)
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    branch, source_todo_dir, source_log_path, worktree_dir = resolve_task_state(
+        repo_root,
+        args.module_id,
+        args.branch,
+    )
+    _, root_log_path = path_for_module(repo_root, args.module_id)
+
+    merged_ref = args.merged_into if ref_exists(repo_root, args.merged_into) else args.merged_into.removeprefix("origin/")
+    merged = branch_exists(repo_root, branch) and ref_exists(repo_root, merged_ref) and branch_is_merged(repo_root, branch, merged_ref)
+    archive_dir = repo_root / args.archive_root / args.module_id
+    prune_list = prune_candidates(repo_root, merged_ref, exclude={branch}) if args.prune_merged_branches else []
+
+    if not args.apply:
+        sys.stdout.write(
+            "\n".join(
+                plan_lines(
+                    module_id=args.module_id,
+                    branch=branch,
+                    merged_into=merged_ref,
+                    merged=merged,
+                    todo_dir=source_todo_dir,
+                    archive_dir=archive_dir,
+                    worktree_dir=worktree_dir,
+                    keep_todo=args.keep_todo,
+                    keep_worktree=args.keep_worktree,
+                    keep_branch=args.keep_branch,
+                    prune_candidates_list=prune_list,
+                )
+            )
+            + "\n"
+        )
+        return 0
+
+    apply_cleanup(
+        args,
+        branch,
+        merged,
+        source_todo_dir,
+        source_log_path,
+        root_log_path,
+        worktree_dir,
+    )
+    print(f"Closed and cleaned up task workspace for module {args.module_id}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/state-logging/SKILL.md
+++ b/skills/state-logging/SKILL.md
@@ -48,6 +48,7 @@ Do not use this skill for:
 | --- | --- | --- |
 | `.project/todo/<module-id>/CURRENT.md` | resumable live state | overwrite in place |
 | `.project/logs/<module-id>.md` | durable meaningful history | append only |
+| `.project/logs/archive/<module-id>/` | archived task workspace after merge cleanup | write once when retiring the task |
 | `.project/todo/<module-id>/00_brainstorm.md` | challenge record and fit check | update during shaping/fit |
 | GitHub issue | work contract | update when scope changes |
 | Pull request | implementation and verification summary | update before review/merge |
@@ -61,6 +62,7 @@ Use one source of truth per concern:
 - `00_brainstorm.md`: design tradeoffs, assumptions, risk, feasibility, and blueprint fit
 - `CURRENT.md`: current status, next step, blocker, branch, PR, latest verification result
 - task log: approach changes, blocker transitions, verification result changes, PR/release state changes
+- `.project/logs/archive/<module-id>/`: retired task workspace snapshot after merge cleanup
 - PR: implementation summary, user-facing verification evidence, risk, rollback, follow-ups
 - release PR: promotion scope, included PRs, release checks, rollback plan
 
@@ -170,6 +172,7 @@ Prefer searchable event labels:
    - Record final merge/release state.
    - Confirm the originating issue closed when the implementation PR merged, or record the blocker/follow-up if it did not.
    - Update `CURRENT.md` to done or archived if the project uses that convention.
+   - When the task branch is truly finished, use `../ora-et-labora/scripts/close_task_workspace.py --repo-root . --module-id <module-id>` to archive the task workspace and retire the owning worktree/local branch. Review the dry-run plan first, then add `--apply`.
 
 ## Context Compaction Recovery
 
@@ -210,6 +213,7 @@ All of these mean the state surface is no longer trustworthy.
 ## Templates And Tools
 
 - `../ora-et-labora/scripts/init_issue_workspace.py`
+- `../ora-et-labora/scripts/close_task_workspace.py`
 - `../ora-et-labora/assets/templates/current.md`
 - `../ora-et-labora/assets/templates/log.md`
 

--- a/skills/worktree-flow/SKILL.md
+++ b/skills/worktree-flow/SKILL.md
@@ -44,6 +44,7 @@ Do not use this skill for:
 - keep the branch synced with `origin/dev`
 - manage Docker runtime behavior across worktrees
 - prevent stale runtime state from being mistaken for current behavior
+- retire merged task worktrees and local branches through the standard cleanup helper when the work is complete
 
 ## Quick Reference
 
@@ -126,6 +127,14 @@ Before marking a PR ready:
 - PR body contains a closing reference to the originating issue, such as `Closes #123`
 - PR body is rendered through the wrapper script or from a rendered body file
 - branch-local `.project` state points to the PR
+
+After the PR merges into `dev` and the task is complete:
+
+- sync the repo/worktree state to current `dev`
+- confirm the originating issue closed as expected
+- archive the merged task workspace with `../ora-et-labora/scripts/close_task_workspace.py --repo-root . --module-id <module-id>`
+- review the dry-run plan before adding `--apply`
+- let the helper retire the owning worktree and local branch instead of ad hoc cleanup commands
 
 ## Auto-Merge Policy
 

--- a/tests/test_close_task_workspace.py
+++ b/tests/test_close_task_workspace.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "skills" / "ora-et-labora" / "scripts" / "close_task_workspace.py"
+
+
+def git(repo_root: Path, *args: str, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=True,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+
+
+class CloseTaskWorkspaceTests(unittest.TestCase):
+    def init_repo(self, tmp: Path) -> Path:
+        repo = tmp / "repo"
+        repo.mkdir()
+        git(repo, "init", "-b", "main")
+        git(repo, "config", "user.email", "codex@example.com")
+        git(repo, "config", "user.name", "Codex")
+        (repo / "README.md").write_text("repo\n")
+        git(repo, "add", "README.md")
+        git(repo, "commit", "-m", "init")
+        git(repo, "checkout", "-b", "dev")
+        return repo
+
+    def make_task_branch(self, repo: Path, module_id: str = "17", branch: str = "feat/17-cleanup") -> Path:
+        worktree = repo / ".project" / "worktrees" / branch.replace("/", "-")
+        worktree.parent.mkdir(parents=True, exist_ok=True)
+        git(repo, "worktree", "add", str(worktree), "-b", branch, "dev")
+        todo_dir = worktree / ".project" / "todo" / module_id
+        log_dir = worktree / ".project" / "logs"
+        todo_dir.mkdir(parents=True, exist_ok=True)
+        log_dir.mkdir(parents=True, exist_ok=True)
+        (todo_dir / "CURRENT.md").write_text(
+            "\n".join(
+                [
+                    "# Current State",
+                    "",
+                    f"- Module: {module_id}",
+                    f"- Branch: {branch}",
+                    "- Status: implementation complete",
+                    "- Next step: open PR",
+                    "- Blockers: none",
+                    "",
+                ]
+            )
+        )
+        (todo_dir / "00_brainstorm.md").write_text("brainstorm\n")
+        (todo_dir / "pr.md").write_text("pr body\n")
+        (log_dir / f"{module_id}.md").write_text(f"# Task Log: {module_id}\n")
+        (worktree / "feature.txt").write_text("done\n")
+        git(repo, "-C", str(worktree), "add", ".")
+        git(repo, "-C", str(worktree), "commit", "-m", "feature")
+        git(repo, "checkout", "dev")
+        return worktree
+
+    def test_dry_run_prints_cleanup_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self.init_repo(Path(tmp))
+            self.make_task_branch(repo)
+            git(repo, "merge", "--no-ff", "feat/17-cleanup", "-m", "merge feature")
+            result = subprocess.run(
+                [
+                    "python",
+                    str(SCRIPT),
+                    "--repo-root",
+                    str(repo),
+                    "--module-id",
+                    "17",
+                    "--merged-into",
+                    "dev",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertIn("Cleanup plan for module 17", result.stdout)
+            self.assertIn(".project/logs/archive/17", result.stdout)
+            self.assertIn("git worktree remove", result.stdout)
+            self.assertIn("git branch -d feat/17-cleanup", result.stdout)
+
+    def test_apply_archives_and_removes_worktree_and_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self.init_repo(Path(tmp))
+            worktree = self.make_task_branch(repo)
+            git(repo, "merge", "--no-ff", "feat/17-cleanup", "-m", "merge feature")
+            subprocess.run(
+                [
+                    "python",
+                    str(SCRIPT),
+                    "--repo-root",
+                    str(repo),
+                    "--module-id",
+                    "17",
+                    "--merged-into",
+                    "dev",
+                    "--apply",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertFalse((repo / ".project" / "todo" / "17").exists())
+            self.assertTrue((repo / ".project" / "logs" / "archive" / "17" / "CURRENT.md").exists())
+            self.assertFalse(worktree.exists())
+            branches = git(repo, "branch", "--list", "feat/17-cleanup").stdout.strip()
+            self.assertEqual(branches, "")
+            log_text = (repo / ".project" / "logs" / "17.md").read_text()
+            self.assertIn("state:closed", log_text)
+
+    def test_apply_refuses_when_branch_not_merged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = self.init_repo(Path(tmp))
+            self.make_task_branch(repo)
+            result = subprocess.run(
+                [
+                    "python",
+                    str(SCRIPT),
+                    "--repo-root",
+                    str(repo),
+                    "--module-id",
+                    "17",
+                    "--merged-into",
+                    "dev",
+                    "--apply",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("Refusing cleanup", result.stderr + result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_template_enforcement_policy.py
+++ b/tests/test_template_enforcement_policy.py
@@ -47,6 +47,14 @@ class TemplateEnforcementPolicyTests(unittest.TestCase):
         self.assertIn("configure_repo_governance.py", repo_init)
         self.assertIn("configure_repo_governance.py", repo_bootstrap)
 
+    def test_suite_docs_reference_cleanup_helper(self) -> None:
+        suite_index = (REPO_ROOT / "skills" / "ora-et-labora" / "SKILL.md").read_text()
+        state_logging = (REPO_ROOT / "skills" / "state-logging" / "SKILL.md").read_text()
+        worktree_flow = (REPO_ROOT / "skills" / "worktree-flow" / "SKILL.md").read_text()
+        self.assertIn("close_task_workspace.py", suite_index)
+        self.assertIn("close_task_workspace.py", state_logging)
+        self.assertIn("close_task_workspace.py", worktree_flow)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- add `close_task_workspace.py` to archive merged task workspaces and retire the owning worktree/local branch through a dry-run-first flow
- add regression tests for dry-run planning, apply cleanup, and unmerged-branch refusal
- wire the cleanup flow into the README, suite index, and relevant execution skills

## Why

Phase 2 closes the post-merge gap in Ora et Labora. The suite could shape work and drive PRs into `dev`, but it had no standard way to archive finished task state or retire merged worktrees and local branches.

## Linked Issue

Closes #17

## Verification

- Local: `python scripts/validate_all.py`
- Browser: Not applicable; workflow/docs/scripts only.
- Browser evidence: Not applicable.
- CI: Pending GitHub `validate`.

## Auto-Merge Eligibility

- Eligible for implementation auto-merge into `dev` after `validate` passes.
- Branch is current with `origin/dev` before push.
- Local verification is recorded in `.project/todo/17/CURRENT.md` and `.project/logs/17.md`.
- Browser verification is not applicable for this workflow/docs/scripts change.

## Blueprint Updates

None.

## Risks / Rollback

Low risk and limited to workflow helpers, documentation, and regression tests. Roll back by reverting the cleanup helper, wrapper, and associated docs/tests.

## Follow-ups

- Continue the roadmap with the public-mode audit gate.
