### PR TITLE
Avoid cleanup log churn

### DIFF
--- a/.project/logs/21.md
+++ b/.project/logs/21.md
@@ -1,0 +1,5 @@
+# Task Log: 21
+
+- 2026-04-25 | state:init | branch:fix/21-no-log-churn | issue:#21 | note:Workspace initialized.
+- 2026-04-25 | approach:change | note:Stop the cleanup helper from appending post-merge `state:closed` entries to versioned task logs; GitHub issue and PR state already own that closeout record.
+- 2026-04-25 | verify:pass | checks:python scripts/validate_all.py | note:No-log-churn cleanup behavior and documentation updates passed the full suite validator.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Repo creation and bootstrap are visibility-aware. Private and internal repos can
 - Browser verification requires evidence, not just a claim.
 - Implementation PRs must reference and close their originating issues.
 - Implementation PR auto-merge is allowed only for eligible `dev` PRs.
-- Merged task work should be archived and retired deliberately, not left as lingering worktrees.
+- Merged task work should be retired deliberately, without creating extra versioned cleanup churn.
 - Release PRs into `main` require explicit approval before merge.
 - Docker behavior across worktrees must be explicit.
 - Public repos keep agent-private state local unless explicitly sanitized.

--- a/skills/ora-et-labora/scripts/close_task_workspace.py
+++ b/skills/ora-et-labora/scripts/close_task_workspace.py
@@ -8,7 +8,6 @@ import shlex
 import shutil
 import subprocess
 import sys
-from datetime import date
 from pathlib import Path
 from typing import Optional
 
@@ -169,22 +168,6 @@ def update_current_for_archive(current_path: Path, archive_rel: str) -> None:
     current_path.write_text("\n".join(new_lines) + "\n")
 
 
-def append_log(log_path: Path, message: str) -> None:
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    with log_path.open("a") as handle:
-        handle.write(message)
-
-
-def ensure_root_log(log_path: Path, source_log_path: Path, module_id: str) -> None:
-    if log_path.exists():
-        return
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    if source_log_path.exists() and source_log_path != log_path:
-        shutil.copy2(source_log_path, log_path)
-        return
-    log_path.write_text(f"# Task Log: {module_id}\n")
-
-
 def active_worktree_branches(repo_root: Path) -> set[str]:
     result = git(repo_root, "worktree", "list", "--porcelain")
     branches: set[str] = set()
@@ -280,15 +263,9 @@ def delete_branch(repo_root: Path, branch: str, force: bool) -> None:
 
 def retire_task_state(
     todo_dir: Path,
-    source_log_path: Path,
-    root_log_path: Path,
-    module_id: str,
-    branch: str,
-    merged_into: str,
     archive_dir: Optional[Path],
     archive_rel: Optional[str],
 ) -> None:
-    ensure_root_log(root_log_path, source_log_path, module_id)
     if archive_dir and archive_rel:
         archive_dir.parent.mkdir(parents=True, exist_ok=True)
         if archive_dir.exists():
@@ -296,22 +273,14 @@ def retire_task_state(
         current_path = todo_dir / "CURRENT.md"
         update_current_for_archive(current_path, archive_rel)
         shutil.move(str(todo_dir), str(archive_dir))
-        suffix = f"archive:{archive_rel} | task-state:archived | note:Archived local task workspace after merge cleanup."
     else:
         shutil.rmtree(todo_dir)
-        suffix = "task-state:removed | note:Removed local task workspace after merge cleanup."
-    append_log(
-        root_log_path,
-        f"- {date.today().isoformat()} | state:closed | branch:{branch} | merged-into:{merged_into} | {suffix}\n",
-    )
 
 def apply_cleanup(
     args: argparse.Namespace,
     branch: str,
     merged: bool,
     source_todo_dir: Path,
-    source_log_path: Path,
-    root_log_path: Path,
     worktree_dir: Path,
 ) -> None:
     repo_root = args.repo_root.resolve()
@@ -322,11 +291,6 @@ def apply_cleanup(
     if not args.keep_todo:
         retire_task_state(
             source_todo_dir,
-            source_log_path,
-            root_log_path,
-            args.module_id,
-            branch,
-            args.merged_into,
             archive_dir,
             archive_rel,
         )
@@ -343,12 +307,11 @@ def apply_cleanup(
 def main() -> int:
     args = parse_args()
     repo_root = args.repo_root.resolve()
-    branch, source_todo_dir, source_log_path, worktree_dir = resolve_task_state(
+    branch, source_todo_dir, _source_log_path, worktree_dir = resolve_task_state(
         repo_root,
         args.module_id,
         args.branch,
     )
-    _, root_log_path = path_for_module(repo_root, args.module_id)
 
     merged_ref = args.merged_into if ref_exists(repo_root, args.merged_into) else args.merged_into.removeprefix("origin/")
     merged = branch_exists(repo_root, branch) and ref_exists(repo_root, merged_ref) and branch_is_merged(repo_root, branch, merged_ref)
@@ -381,8 +344,6 @@ def main() -> int:
         branch,
         merged,
         source_todo_dir,
-        source_log_path,
-        root_log_path,
         worktree_dir,
     )
     print(f"Closed and cleaned up task workspace for module {args.module_id}.")

--- a/skills/state-logging/SKILL.md
+++ b/skills/state-logging/SKILL.md
@@ -60,6 +60,7 @@ Use one source of truth per concern:
 - GitHub issue: issue scope, acceptance criteria, and verification plan
 - local task workspace (`00_brainstorm.md`, `CURRENT.md`): design tradeoffs, next step, blockers, and branch-local resumability
 - task log: approach changes, blocker transitions, verification result changes, PR/release state changes
+- GitHub issue and PR: final merged/closed state after integration
 - PR: implementation summary, user-facing verification evidence, risk, rollback, follow-ups
 - release PR: promotion scope, included PRs, release checks, rollback plan
 
@@ -103,8 +104,7 @@ Meaningful deltas:
 - verification failed
 - verification passed after previously failing or being pending
 - browser evidence was collected
-- PR opened, retargeted, marked ready, merged, or blocked
-- originating issue was closed by PR merge or failed to close as expected
+- PR opened, retargeted, marked ready, or blocked
 - release train prepared, checked, or merged
 - blueprint changed because durable knowledge changed
 
@@ -166,10 +166,10 @@ Prefer searchable event labels:
    - task log should include the verification state.
    - PR body should include the originating issue closing reference.
 7. After merge or release, close the loop.
-   - Record final merge/release state.
    - Confirm the originating issue closed when the implementation PR merged, or record the blocker/follow-up if it did not.
    - Update the local task workspace to done if the project keeps it briefly during handoff.
    - When the task branch is truly finished, use `../ora-et-labora/scripts/close_task_workspace.py --repo-root . --module-id <module-id>` to remove the local task workspace and retire the owning worktree/local branch. Review the dry-run plan first, then add `--apply`.
+   - Standard cleanup should not create a new versioned task-log delta just to record that the PR merged; GitHub issue and PR state already own that closeout record.
 
 ## Context Compaction Recovery
 

--- a/skills/worktree-flow/SKILL.md
+++ b/skills/worktree-flow/SKILL.md
@@ -136,6 +136,7 @@ After the PR merges into `dev` and the task is complete:
 - remove the merged local task workspace with `../ora-et-labora/scripts/close_task_workspace.py --repo-root . --module-id <module-id>`
 - review the dry-run plan before adding `--apply`
 - let the helper retire the owning worktree and local branch instead of ad hoc cleanup commands
+- do not create a new versioned cleanup commit just to record that the PR merged; GitHub already owns that state
 
 ## Auto-Merge Policy
 

--- a/tests/test_close_task_workspace.py
+++ b/tests/test_close_task_workspace.py
@@ -118,8 +118,8 @@ class CloseTaskWorkspaceTests(unittest.TestCase):
             branches = git(repo, "branch", "--list", "feat/17-cleanup").stdout.strip()
             self.assertEqual(branches, "")
             log_text = (repo / ".project" / "logs" / "17.md").read_text()
-            self.assertIn("state:closed", log_text)
-            self.assertIn("task-state:removed", log_text)
+            self.assertNotIn("state:closed", log_text)
+            self.assertNotIn("task-state:removed", log_text)
 
     def test_apply_can_archive_task_state_when_requested(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -148,8 +148,8 @@ class CloseTaskWorkspaceTests(unittest.TestCase):
             self.assertTrue((repo / ".project" / "local-archive" / "17" / "CURRENT.md").exists())
             self.assertFalse(worktree.exists())
             log_text = (repo / ".project" / "logs" / "17.md").read_text()
-            self.assertIn("task-state:archived", log_text)
-            self.assertIn(".project/local-archive/17", log_text)
+            self.assertNotIn("task-state:archived", log_text)
+            self.assertNotIn(".project/local-archive/17", log_text)
 
     def test_apply_refuses_when_branch_not_merged(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- stop `close_task_workspace.py` from appending post-merge `state:closed` entries to versioned task logs by default
- update state-logging and worktree-flow docs so GitHub issue/PR state is the canonical closeout record after merge
- keep the helper focused on local task-state, worktree, and branch retirement without leaving `dev` dirty

## Why

The task-state simplification in PR #20 still left one versioned post-merge mutation path: local cleanup appended a `state:closed` line to `.project/logs/<module-id>.md`. That would dirty `dev` again after cleanup, which defeats the purpose of making task workspaces local-only.

## Linked Issue

Closes #21

## Verification

- Local: `python scripts/validate_all.py`
- Browser: Not applicable; workflow/docs/scripts only.
- Browser evidence: Not applicable.
- CI: Pending GitHub `validate`.

## Auto-Merge Eligibility

- Eligible for implementation auto-merge into `dev` after `validate` passes.
- Branch is current with `origin/dev` before push.
- Local verification is recorded in `.project/logs/21.md`.
- Browser verification is not applicable for this workflow/docs/scripts change.

## Blueprint Updates

Updated the suite docs so standard cleanup no longer implies a versioned post-merge log mutation.

## Risks / Rollback

Low risk and limited to the cleanup helper, documentation, and regression tests. Roll back by reverting this follow-up commit if needed.

## Follow-ups

- After merge, rerun cleanup for the local stale worktrees so the repo and local runtime state both end clean.
