### PR TITLE
docs: release parallel epic workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,6 @@ Scope: applies to `personal/ora-et-labora/**`.
 ## Branch Flow
 
 - Normal work goes `dev` -> `feat|fix|chore/<issue>-<slug>` -> PR to `dev`.
-- Epic work goes `dev` -> `epic/<slug>` with an early draft PR to `dev`; child issue PRs target the epic branch.
+- Epic work goes `dev` -> `epic/<slug>` with an early draft PR to `dev`; child issue PRs target the epic branch, and parallel epics must rebase on `origin/dev` after other epics merge or shared contracts change.
 - Hotfix work goes `main` -> `hotfix/<issue>-<slug>` -> PR to `main`, then must be reconciled back to `dev`.
 - Stable releases promote grouped `dev` work -> `main` through release PRs.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The key split is intentional: task-local execution state under `.project/todo/` 
 
 Implementation then happens inside the worktree, with verification driven by the type of change. Frontend work is not "tested" in the abstract; it is verified in the browser, with Playwright evidence collected into a stable repo-local log path. Docker-backed projects are handled with explicit worktree rules so switching branches does not turn into port collisions and stale containers.
 
-The branch flow is lane-based and PR-first. Normal work targets `dev`; epic work uses `epic/<slug>` plus an early draft PR to `dev`; urgent hotfixes target `main` first and then reconcile back to `dev`. Implementation PRs may use agent auto-merge only after branch freshness, verification, CI/review, issue-closure, and state-logging gates are satisfied. Stable promotion happens through grouped `dev` to `main` release PRs, and release or hotfix PRs into `main` require explicit user approval before merge.
+The branch flow is lane-based and PR-first. Normal work targets `dev`; epic work uses `epic/<slug>` plus an early draft PR to `dev`; urgent hotfixes target `main` first and then reconcile back to `dev`. Parallel epics are allowed, but they must stay rebased on `origin/dev`, and affected epics must rebase immediately when another epic merges or changes shared contracts. Implementation PRs may use agent auto-merge only after branch freshness, verification, CI/review, issue-closure, and state-logging gates are satisfied. Stable promotion happens through grouped `dev` to `main` release PRs, and release or hotfix PRs into `main` require explicit user approval before merge.
 
 Repo creation and bootstrap are visibility-aware. Private and internal repos can version durable `.project/` surfaces such as `.project/blueprint/` and concise `.project/logs/`, while keeping local task workspaces under `.project/todo/` local-only. Public repos keep `.project/` local by default and publish only sanitized contributor-facing docs and GitHub templates.
 
@@ -46,7 +46,7 @@ Repo creation and bootstrap are visibility-aware. Private and internal repos can
    - do not assemble long GitHub bodies inline
 4. Initialize branch-local state.
    - normal lane: one issue, one branch, one worktree, one local `CURRENT.md`, one append-only task log
-   - epic lane: `epic/<slug>` branch plus early draft PR to `dev`, with child issue PRs targeting the epic branch
+   - epic lane: `epic/<slug>` branch plus early draft PR to `dev`, with child issue PRs targeting the epic branch and final epic PR tracking child issue closure
    - hotfix lane: `main`-based branch for urgent stable fixes, followed by mandatory reconcile to `dev`
 5. Implement.
    - work from the worktree
@@ -56,7 +56,7 @@ Repo creation and bootstrap are visibility-aware. Private and internal repos can
    - store browser evidence under `.project/logs/playwright/<task-id>/<run-id>/`
 7. Open or update the PR for the selected lane.
    - normal PRs target `dev`
-   - epic child PRs target `epic/<slug>` and link the parent epic issue
+   - epic child PRs target `epic/<slug>` and link the parent epic issue; final epic PRs to `dev` include closing keywords for all child issues or explicitly track closure through the parent epic issue
    - hotfix PRs target `main` and require explicit user approval
    - summarize implementation, verification, and blueprint impact
    - include `Closes #<issue>` for the originating issue

--- a/skills/ora-et-labora/SKILL.md
+++ b/skills/ora-et-labora/SKILL.md
@@ -172,9 +172,17 @@ Preferred worktree folder names avoid slashes, such as `fix-123-login-race`, `ep
 Branch lanes:
 
 - Normal lane: `dev -> feat|fix|chore/<issue>-<slug> -> PR to dev -> grouped release PR to main`. Use this for ordinary features, fixes, refactors, docs, and chores.
-- Epic lane: `dev -> epic/<slug> -> child issue branches -> PRs to epic/<slug> -> draft epic PR becomes ready -> PR to dev`. Use this only when several child PRs must integrate together before the combined outcome is safe on `dev`. Open a draft PR from `epic/<slug>` to `dev` immediately after creating the epic branch unless the user explicitly says the epic is local or experimental. Each child PR must link its issue and the parent epic issue or tracking issue. The draft epic PR is the coordination surface for scope, child issues, checklist/status, CI, verification plan, and final readiness; mark it ready only after child work is merged, verified, and reconciled with latest `dev`.
+- Epic lane: `dev -> epic/<slug> -> child issue branches -> PRs to epic/<slug> -> draft epic PR becomes ready -> PR to dev`. Use this only when several child PRs must integrate together before the combined outcome is safe on `dev`. Open a draft PR from `epic/<slug>` to `dev` immediately after creating the epic branch unless the user explicitly says the epic is local or experimental. Each child PR must link its issue and the parent epic issue or tracking issue. Because GitHub closing keywords in child PRs targeting an epic branch may not close issues until the work reaches the default branch, the final epic PR into `dev` must include `Closes #...` references for all child issues, or the parent epic issue must explicitly track child closure. The draft epic PR is the coordination surface for scope, child issues, checklist/status, CI, verification plan, and final readiness; mark it ready only after child work is merged, verified, and reconciled with latest `dev`.
 - Hotfix lane: `main -> hotfix/<issue>-<slug> -> PR to main -> reconcile to dev`. Use this for production breakage, deployment-blocking regressions, security-sensitive fixes, data-loss risk, or other priority fixes that should not wait for the next `dev -> main` release. Keep the patch narrow, verify against the stable behavior, require explicit user approval before merging to `main`, and immediately backport, merge, or cherry-pick the fix into `dev`.
 - Release stabilization lane: `dev -> release PR to main`, with only release-blocking fixes admitted into the release path. Non-blocking new work continues targeting `dev` or an epic lane.
+
+Parallel epic discipline:
+
+- Multiple `epic/<slug>` branches may exist in parallel, but every active epic draft PR must stay visible and describe overlapping surfaces.
+- Each epic branch must rebase on `origin/dev` regularly and before its draft PR is marked ready.
+- After one epic merges into `dev`, all other active epic branches must rebase on updated `origin/dev` before merging more child PRs or marking the epic ready.
+- If an epic changes shared contracts, APIs, schemas, auth, routing, deployment config, or core UI conventions, affected parallel epics must rebase immediately and record the impact in their draft PRs or task state.
+- If two epics modify the same contract, surface the overlap in both draft PRs and decide merge order. If one epic depends on another, make the dependency explicit and keep the dependent epic blocked or stacked until the base epic lands.
 
 Merge and approval rules:
 
@@ -282,7 +290,7 @@ For any nontrivial task, completion requires:
 - work performed in the owning worktree
 - relevant verification completed
 - browser evidence preserved when frontend behavior changed
-- PR opened or updated against `dev`
+- PR opened or updated against the selected lane target (`dev`, `epic/<slug>`, or `main` for hotfixes)
 - PR body references and closes the originating issue
 - task state and log reflect the latest truth
 - merged local task state is retired and the worktree is cleaned up when the branch is complete

--- a/skills/worktree-flow/SKILL.md
+++ b/skills/worktree-flow/SKILL.md
@@ -88,9 +88,19 @@ Worktree folder names should avoid slashes:
 Select the lane before creating the branch or worktree. This section overrides older shorthand that every branch targets `dev`.
 
 - Normal lane: `dev -> feat|fix|chore/<issue>-<slug> -> PR to dev`. Use for independently deliverable issues.
-- Epic lane: `dev -> epic/<slug> -> child issue branches -> PRs to epic/<slug> -> draft epic PR to dev`. Use only when several child PRs must integrate together before the outcome is safe on `dev`. Open the draft epic PR to `dev` immediately after creating `epic/<slug>` unless the user explicitly says the epic is local or experimental.
+- Epic lane: `dev -> epic/<slug> -> child issue branches -> PRs to epic/<slug> -> draft epic PR to dev`. Use only when several child PRs must integrate together before the outcome is safe on `dev`. Open the draft epic PR to `dev` immediately after creating `epic/<slug>` unless the user explicitly says the epic is local or experimental. Because GitHub closing keywords in child PRs targeting an epic branch may not close issues until the work reaches the default branch, the final epic PR into `dev` must include `Closes #...` references for all child issues, or the parent epic issue must explicitly track child closure.
 - Hotfix lane: `main -> hotfix/<issue>-<slug> -> PR to main -> reconcile to dev`. Use for urgent production, security, data-loss, or deployment-blocking fixes. Hotfix PRs to `main` require explicit user approval before merge.
 - Release stabilization lane belongs to `release-train`, not normal implementation flow.
+
+## Parallel Epic Discipline
+
+Multiple `epic/<slug>` branches may exist in parallel, but they require explicit sync discipline.
+
+- Keep every active epic draft PR visible and use it to describe overlapping files, contracts, routes, schemas, APIs, auth, deployment config, or core UI surfaces.
+- Rebase each epic branch on `origin/dev` regularly and before marking the draft epic PR ready.
+- When one epic merges into `dev`, every other active epic must rebase on updated `origin/dev` before accepting more child PRs or marking ready.
+- When one epic changes a shared contract, all affected parallel epics must rebase immediately and record the impact in the draft PR or branch-local task state.
+- If two epics modify the same contract, decide and document merge order. If one epic depends on another, keep it blocked or explicitly stacked until the base epic lands.
 
 ## Worktree Procedure
 
@@ -123,7 +133,7 @@ Select the lane before creating the branch or worktree. This section overrides o
 7. Rebase on the selected upstream at required gates.
    - Normal branches rebase on `origin/dev`.
    - Epic child branches rebase on the remote epic branch.
-   - Epic parent branches rebase on `origin/dev` before marking the draft PR ready.
+   - Epic parent branches rebase on `origin/dev` regularly, after other epics merge, after shared-contract changes, and before marking the draft PR ready.
    - Hotfix branches rebase on `origin/main`.
    - Rebase at session start, after relevant upstream merges, before pushing, and before marking a PR ready.
 8. Before PR readiness, run the relevant verification.
@@ -144,7 +154,7 @@ Before marking a PR ready:
 - relevant local checks are current
 - browser evidence exists for frontend behavior changes
 - Docker/runtime state was rebuilt or restarted after sync when relevant
-- PR body contains a closing reference to the originating issue, such as `Closes #123`
+- PR body contains a closing reference to the originating issue, such as `Closes #123`; final epic PRs to `dev` include closing references for all child issues or explicitly track closure through the parent epic issue
 - PR body is rendered through the wrapper script or from a rendered body file
 - branch-local `.project` state points to the PR
 
@@ -166,7 +176,7 @@ Auto-merge gates for implementation PRs:
 - PR target is `dev` for normal work or the owning `epic/<slug>` for epic child work; it is not `main`.
 - PR is not a release PR, hotfix-to-stable PR, emergency production promotion, or epic parent draft PR being marked ready.
 - PR body includes a closing reference for the originating issue, such as `Closes #123`.
-- Branch is rebased on the current selected upstream base.
+- Branch is rebased on the current selected upstream base; active epic branches are also rebased after other epics merge or shared contracts change.
 - Local verification is recorded in `CURRENT.md`, the task log, and the PR body.
 - Browser evidence exists when frontend-visible behavior changed, or the PR body explains why browser verification is not applicable.
 - Required CI is passing, or GitHub auto-merge is enabled while required CI is pending.
@@ -238,7 +248,7 @@ When two active worktrees overlap:
 - prefer merging the branch with fewer dependencies first
 - rebase the other branch on `origin/dev` immediately after the first merge
 - resolve conflicts in the dependent branch
-- use epic branches for deliberate multi-issue integration; use stacked PRs only temporarily when one branch depends on another unmerged branch
+- use epic branches for deliberate multi-issue integration; keep parallel epics rebased on `origin/dev`; use stacked PRs only temporarily when one branch depends on another unmerged branch
 - retarget stacked PRs to the selected lane target after the base PR merges
 
 Do not let two worktrees silently modify the same contract without surfacing overlap in PRs or task logs.
@@ -248,6 +258,8 @@ Do not let two worktrees silently modify the same contract without surfacing ove
 - "I created a worktree but kept editing the main checkout."
 - "The PR targets `main` for normal implementation work."
 - "The child PR targets `dev` even though it belongs to an active epic branch."
+- "Another epic merged to `dev`, but this epic kept accepting child PRs without rebasing."
+- "The final epic PR relies on child PR closing keywords that may not close issues from a non-default epic branch."
 - "I created `module/<slug>` instead of the current `epic/<slug>` lane."
 - "The PR references the issue in prose but does not use a closing keyword."
 - "I pushed before rebasing on `origin/dev`."


### PR DESCRIPTION
## Release scope

Promote the parallel-epic workflow clarification from `dev` to `main`.

Included changes:

- Add explicit parallel epic discipline for multiple active `epic/<slug>` branches.
- Require active epics to rebase on `origin/dev` after other epics merge or shared contracts change.
- Clarify that final epic PRs into `dev` should include closing keywords for child issues, or explicitly track child closure through the parent epic issue.
- Fix completion wording so PRs are opened against the selected lane target, not always `dev`.
- Align README, AGENTS, umbrella skill, and worktree-flow wording.

## Release checks

- Local validation: not run, per operator preference not to run validation unless explicitly requested.
- CI: pending/not checked locally.
- Browser verification: not applicable; documentation/process-only change.
- Migration/schema: not applicable.

## Operational notes

Installed local skills were synced from this repo with:

```bash
python scripts/sync_local_suite.py --overwrite
```

Restart Codex after syncing to reload the skill list.

## Risks

Main risk is process ambiguity around long-lived parallel epics. This release reduces that risk by making rebase and child-issue closure expectations explicit.

## Rollback

Revert the release merge commit on `main` if the parallel epic policy needs to be withdrawn.
