### PR TITLE
docs: release epic templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Repo creation and bootstrap are visibility-aware. Private and internal repos can
    - do not assemble long GitHub bodies inline
 4. Initialize branch-local state.
    - normal lane: one issue, one branch, one worktree, one local `CURRENT.md`, one append-only task log
-   - epic lane: `epic/<slug>` branch plus early draft PR to `dev`, with child issue PRs targeting the epic branch and final epic PR tracking child issue closure
+   - epic lane: `epic/<slug>` branch plus early draft PR to `dev` rendered from the epic PR template, with child issue PRs targeting the epic branch and final epic PR tracking child issue closure
    - hotfix lane: `main`-based branch for urgent stable fixes, followed by mandatory reconcile to `dev`
 5. Implement.
    - work from the worktree
@@ -107,7 +107,7 @@ The suite includes:
 - a shared workflow overview under `skills/ora-et-labora`
 - focused trigger skills for each major workflow phase
 - detailed self-contained `SKILL.md` bodies with procedure, red flags, rationalization counters, and completion checklists
-- issue, PR, release, brainstorm, current-state, and log templates
+- issue, epic issue, PR, epic draft PR, release, brainstorm, current-state, and log templates
 - bootstrap assets for `.github/` and `.project/blueprint/`
 - helper scripts for template rendering, issue/PR creation, issue workspace initialization, visibility-aware bootstrap, and Playwright artifact collection
 - a governance helper that can plan or apply default repo settings and a standard issue label set

--- a/skills/issue-shaping/SKILL.md
+++ b/skills/issue-shaping/SKILL.md
@@ -107,11 +107,12 @@ If the same paragraph appears in all artifacts, the workflow is becoming redunda
    - List browser checks if UI behavior is touched.
    - List CI expectations if the work will enter PR flow.
 7. Create or update `00_brainstorm.md`.
-   - Use the brainstorm template when starting a new module.
+   - Use the brainstorm template when starting a new task or epic.
    - Keep it focused on challenge and feasibility, not implementation progress.
 8. Draft or refine the GitHub issue body.
    - Use `issue-bug.md` for bugs.
    - Use `issue-feature.md` for features.
+   - Use `issue-epic.md` for multi-issue outcomes that need an epic lane.
    - Standard path: use `../ora-et-labora/scripts/create_issue_from_template.py`.
    - Minimum fallback: render a body file first, then use `gh issue create --body-file <file>`.
    - Do not hand-write multi-section issue markdown directly into `gh issue create`.
@@ -209,6 +210,7 @@ Verification plan:
 - `../ora-et-labora/assets/templates/brainstorm.md`
 - `../ora-et-labora/assets/templates/issue-bug.md`
 - `../ora-et-labora/assets/templates/issue-feature.md`
+- `../ora-et-labora/assets/templates/issue-epic.md`
 - `../ora-et-labora/scripts/render_template.py`
 - `../ora-et-labora/scripts/create_issue_from_template.py`
 

--- a/skills/ora-et-labora/SKILL.md
+++ b/skills/ora-et-labora/SKILL.md
@@ -172,7 +172,7 @@ Preferred worktree folder names avoid slashes, such as `fix-123-login-race`, `ep
 Branch lanes:
 
 - Normal lane: `dev -> feat|fix|chore/<issue>-<slug> -> PR to dev -> grouped release PR to main`. Use this for ordinary features, fixes, refactors, docs, and chores.
-- Epic lane: `dev -> epic/<slug> -> child issue branches -> PRs to epic/<slug> -> draft epic PR becomes ready -> PR to dev`. Use this only when several child PRs must integrate together before the combined outcome is safe on `dev`. Open a draft PR from `epic/<slug>` to `dev` immediately after creating the epic branch unless the user explicitly says the epic is local or experimental. Each child PR must link its issue and the parent epic issue or tracking issue. Because GitHub closing keywords in child PRs targeting an epic branch may not close issues until the work reaches the default branch, the final epic PR into `dev` must include `Closes #...` references for all child issues, or the parent epic issue must explicitly track child closure. The draft epic PR is the coordination surface for scope, child issues, checklist/status, CI, verification plan, and final readiness; mark it ready only after child work is merged, verified, and reconciled with latest `dev`.
+- Epic lane: `dev -> epic/<slug> -> child issue branches -> PRs to epic/<slug> -> draft epic PR becomes ready -> PR to dev`. Use this only when several child PRs must integrate together before the combined outcome is safe on `dev`. Open a draft PR from `epic/<slug>` to `dev` immediately after creating the epic branch unless the user explicitly says the epic is local or experimental. Render the draft epic PR from `epic-pr.md`. Each child PR must link its issue and the parent epic issue or tracking issue. Because GitHub closing keywords in child PRs targeting an epic branch may not close issues until the work reaches the default branch, the final epic PR into `dev` must include `Closes #...` references for all child issues, or the parent epic issue must explicitly track child closure. The draft epic PR is the coordination surface for scope, child issues, checklist/status, overlapping surfaces, rebase status, CI, verification plan, child issue closure plan, and final readiness; mark it ready only after child work is merged, verified, and reconciled with latest `dev`.
 - Hotfix lane: `main -> hotfix/<issue>-<slug> -> PR to main -> reconcile to dev`. Use this for production breakage, deployment-blocking regressions, security-sensitive fixes, data-loss risk, or other priority fixes that should not wait for the next `dev -> main` release. Keep the patch narrow, verify against the stable behavior, require explicit user approval before merging to `main`, and immediately backport, merge, or cherry-pick the fix into `dev`.
 - Release stabilization lane: `dev -> release PR to main`, with only release-blocking fixes admitted into the release path. Non-blocking new work continues targeting `dev` or an epic lane.
 
@@ -233,7 +233,9 @@ Template assets live under `assets/templates/`:
 
 - `issue-bug.md`
 - `issue-feature.md`
+- `issue-epic.md`
 - `pr.md`
+- `epic-pr.md`
 - `release-pr.md`
 - `brainstorm.md`
 - `current.md`

--- a/skills/ora-et-labora/assets/templates/epic-pr.md
+++ b/skills/ora-et-labora/assets/templates/epic-pr.md
@@ -1,0 +1,52 @@
+## Epic Summary
+
+{{SUMMARY}}
+
+## Parent Epic Issue
+
+{{PARENT_EPIC_ISSUE}}
+
+## Child Issues / PRs
+
+{{CHILD_ISSUES_AND_PRS}}
+
+## Integration Status
+
+{{INTEGRATION_STATUS}}
+
+## Overlapping Surfaces / Contracts
+
+{{OVERLAPPING_SURFACES}}
+
+## Rebase Status
+
+- Base: `origin/dev`
+- Latest rebase: {{LATEST_REBASE_STATUS}}
+- Parallel epic impacts: {{PARALLEL_EPIC_IMPACTS}}
+
+## Verification Plan
+
+{{VERIFICATION_PLAN}}
+
+## Verification Status
+
+- Local: {{LOCAL_VERIFICATION}}
+- Browser: {{BROWSER_VERIFICATION}}
+- Browser evidence: {{BROWSER_EVIDENCE}}
+- CI: {{CI_VERIFICATION}}
+
+## Child Issue Closure Plan
+
+{{CHILD_ISSUE_CLOSURE_PLAN}}
+
+## Readiness Gate
+
+{{READINESS_GATE}}
+
+## Risks / Rollback
+
+{{RISKS_AND_ROLLBACK}}
+
+## Follow-ups
+
+{{FOLLOW_UPS}}

--- a/skills/ora-et-labora/assets/templates/issue-epic.md
+++ b/skills/ora-et-labora/assets/templates/issue-epic.md
@@ -1,0 +1,35 @@
+## Outcome
+
+{{OUTCOME}}
+
+## Why This Is An Epic
+
+{{WHY_EPIC}}
+
+## Child Issues
+
+{{CHILD_ISSUES}}
+
+## Shared Surfaces / Contracts
+
+{{SHARED_SURFACES}}
+
+## Non-Goals
+
+{{NON_GOALS}}
+
+## Integration Plan
+
+{{INTEGRATION_PLAN}}
+
+## Verification Plan
+
+{{VERIFICATION_PLAN}}
+
+## Readiness Criteria
+
+{{READINESS_CRITERIA}}
+
+## Risks / Rollback
+
+{{RISKS_AND_ROLLBACK}}

--- a/skills/worktree-flow/SKILL.md
+++ b/skills/worktree-flow/SKILL.md
@@ -88,7 +88,7 @@ Worktree folder names should avoid slashes:
 Select the lane before creating the branch or worktree. This section overrides older shorthand that every branch targets `dev`.
 
 - Normal lane: `dev -> feat|fix|chore/<issue>-<slug> -> PR to dev`. Use for independently deliverable issues.
-- Epic lane: `dev -> epic/<slug> -> child issue branches -> PRs to epic/<slug> -> draft epic PR to dev`. Use only when several child PRs must integrate together before the outcome is safe on `dev`. Open the draft epic PR to `dev` immediately after creating `epic/<slug>` unless the user explicitly says the epic is local or experimental. Because GitHub closing keywords in child PRs targeting an epic branch may not close issues until the work reaches the default branch, the final epic PR into `dev` must include `Closes #...` references for all child issues, or the parent epic issue must explicitly track child closure.
+- Epic lane: `dev -> epic/<slug> -> child issue branches -> PRs to epic/<slug> -> draft epic PR to dev`. Use only when several child PRs must integrate together before the outcome is safe on `dev`. Open the draft epic PR to `dev` immediately after creating `epic/<slug>` unless the user explicitly says the epic is local or experimental. Render the draft epic PR from `epic-pr.md`. Because GitHub closing keywords in child PRs targeting an epic branch may not close issues until the work reaches the default branch, the final epic PR into `dev` must include `Closes #...` references for all child issues, or the parent epic issue must explicitly track child closure.
 - Hotfix lane: `main -> hotfix/<issue>-<slug> -> PR to main -> reconcile to dev`. Use for urgent production, security, data-loss, or deployment-blocking fixes. Hotfix PRs to `main` require explicit user approval before merge.
 - Release stabilization lane belongs to `release-train`, not normal implementation flow.
 
@@ -123,7 +123,7 @@ Multiple `epic/<slug>` branches may exist in parallel, but they require explicit
    - Treat `.project/todo` as local task workspace state, not published repo history.
 6. Open or update the lane PR.
    - Normal branch base: `dev`.
-   - Epic parent branch: open a draft PR from `epic/<slug>` to `dev` immediately as the coordination surface. Include scope, child issues, checklist/status, CI, verification plan, and final readiness criteria.
+   - Epic parent branch: open a draft PR from `epic/<slug>` to `dev` immediately as the coordination surface. Render it from `../ora-et-labora/assets/templates/epic-pr.md`. Include scope, child issues, checklist/status, overlapping surfaces, rebase status, CI, verification plan, child issue closure plan, and final readiness criteria.
    - Epic child branch base: the owning `epic/<slug>`. Link the child issue and parent epic issue or tracking issue.
    - Hotfix branch base: `main`; require explicit user approval before merge and record the plan to reconcile back to `dev`.
    - Standard path: use `../ora-et-labora/scripts/create_pr_from_template.py`.


### PR DESCRIPTION
## Release scope

Promote epic workflow templates from `dev` to `main`.

Included changes:

- Add `issue-epic.md` for multi-issue outcomes that need an epic lane.
- Add `epic-pr.md` for early draft PRs from `epic/<slug>` to `dev`.
- Update Ora et Labora guidance so epic draft PRs are rendered from the epic PR template.
- Update worktree-flow guidance to include overlapping surfaces, rebase status, verification plan, child issue closure plan, and readiness gates in epic PRs.
- Update issue-shaping so epic issues use the new epic issue template.
- Update README template inventory.

## Release checks

- Local validation: not run, per operator preference not to run validation unless explicitly requested.
- CI: pending/not checked locally.
- Browser verification: not applicable; documentation/template change.
- Migration/schema: not applicable.

## Operational notes

After release, sync installed local skills with:

```bash
python scripts/sync_local_suite.py --overwrite
```

Restart Codex after syncing to reload the skill list.

## Risks

Main risk is process overhead. The templates are intentionally narrow and only required for the epic lane, not normal one-issue work.

## Rollback

Revert the release merge commit on `main` if the epic templates need to be withdrawn.
