### PR TITLE
Load research delegate env before model defaults

### DIFF
--- a/skills/research-writing-delegate/SKILL.md
+++ b/skills/research-writing-delegate/SKILL.md
@@ -30,7 +30,7 @@ Copy `.env.example` to a local untracked `.env` if needed:
 cp skills/research-writing-delegate/.env.example .env
 ```
 
-Keep `.env` local-only. The committed file is only a template. Optional OpenRouter request metadata can be set with `OPENROUTER_SITE_URL` and `OPENROUTER_APP_NAME`.
+Keep `.env` local-only. The committed file is only a template. The helper automatically loads `skills/research-writing-delegate/.env` when present; pass `--env-file <path>` to use a different local file. Optional OpenRouter request metadata can be set with `OPENROUTER_SITE_URL` and `OPENROUTER_APP_NAME`.
 
 ## Prompt And Template Assets
 
@@ -161,7 +161,7 @@ python skills/research-writing-delegate/scripts/call_delegate.py \
   --out .project/todo/<task-id>/delegate-output.json
 ```
 
-Use `--env-file .env` only with an untracked local file.
+Use `--env-file <path>` only with an untracked local file. CLI flags such as `--model` override `.env` values.
 
 ## Common Mistakes
 

--- a/skills/research-writing-delegate/scripts/call_delegate.py
+++ b/skills/research-writing-delegate/scripts/call_delegate.py
@@ -20,6 +20,7 @@ DEFAULT_PROVIDER = "openrouter"
 DEFAULT_OPENROUTER_MODEL = "openai/gpt-5.2"
 DEFAULT_OPENAI_MODEL = "gpt-5.5"
 SKILL_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_ENV_FILE_PATH = SKILL_DIR / ".env"
 DEFAULT_SYSTEM_PROMPT_PATH = SKILL_DIR / "prompts" / "delegate_system.md"
 ALLOWED_TASK_TYPES = {
     "draft_paragraph",
@@ -63,18 +64,21 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--provider",
         choices=["openrouter", "openai"],
-        default=os.environ.get("RESEARCH_WRITING_DELEGATE_PROVIDER", DEFAULT_PROVIDER),
     )
     parser.add_argument("--brief-kind", choices=["initial", "revision"], default="initial")
     parser.add_argument("--brief", required=True, help="Path to brief JSON, or '-' for stdin.")
     parser.add_argument("--out", type=Path, help="Write artifact JSON to this path.")
-    parser.add_argument("--model", default=os.environ.get("RESEARCH_WRITING_DELEGATE_MODEL"))
+    parser.add_argument("--model")
     parser.add_argument("--system-prompt", type=Path, default=DEFAULT_SYSTEM_PROMPT_PATH)
-    parser.add_argument("--env-file", type=Path, help="Optional local untracked .env file.")
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        help="Optional local untracked .env file. Defaults to skill-local .env when present.",
+    )
     parser.add_argument("--max-output-tokens", type=int, default=1800)
     parser.add_argument("--temperature", type=float, default=0.4)
-    parser.add_argument("--openrouter-site-url", default=os.environ.get("OPENROUTER_SITE_URL"))
-    parser.add_argument("--openrouter-app-name", default=os.environ.get("OPENROUTER_APP_NAME"))
+    parser.add_argument("--openrouter-site-url")
+    parser.add_argument("--openrouter-app-name")
     parser.add_argument("--dry-run", action="store_true", help="Print sanitized request payload without calling the API.")
     return parser.parse_args()
 
@@ -92,6 +96,14 @@ def load_env_file(path: Path, environ: dict[str, str] | None = None) -> None:
         value = value.strip().strip('"').strip("'")
         if key and key not in target:
             target[key] = value
+
+
+def resolve_env_file(explicit_env_file: Path | None) -> Path | None:
+    if explicit_env_file is not None:
+        return explicit_env_file
+    if DEFAULT_ENV_FILE_PATH.exists():
+        return DEFAULT_ENV_FILE_PATH
+    return None
 
 
 def load_brief(path_value: str) -> dict[str, Any]:
@@ -225,12 +237,26 @@ def validate_brief(brief: dict[str, Any], brief_kind: str) -> None:
         raise SystemExit("Brief validation failed:\n- " + "\n- ".join(errors))
 
 
+def resolve_provider(provider: str | None) -> str:
+    return (provider or os.environ.get("RESEARCH_WRITING_DELEGATE_PROVIDER", DEFAULT_PROVIDER)).lower()
+
+
 def resolve_model(provider: str, model: str | None) -> str:
+    if model is None:
+        model = os.environ.get("RESEARCH_WRITING_DELEGATE_MODEL")
     if model:
         return model
     if provider == "openrouter":
         return DEFAULT_OPENROUTER_MODEL
     return DEFAULT_OPENAI_MODEL
+
+
+def resolve_openrouter_site_url(value: str | None) -> str | None:
+    return value or os.environ.get("OPENROUTER_SITE_URL")
+
+
+def resolve_openrouter_app_name(value: str | None) -> str | None:
+    return value or os.environ.get("OPENROUTER_APP_NAME")
 
 
 def build_request(
@@ -406,10 +432,11 @@ def build_artifact(
 
 def main() -> int:
     args = parse_args()
-    if args.env_file:
-        load_env_file(args.env_file)
+    env_file = resolve_env_file(args.env_file)
+    if env_file is not None:
+        load_env_file(env_file)
 
-    provider = args.provider.lower()
+    provider = resolve_provider(args.provider)
     brief = load_brief(args.brief)
     validate_brief(brief, args.brief_kind)
     model = resolve_model(provider, args.model)
@@ -433,8 +460,8 @@ def main() -> int:
         provider,
         endpoint,
         api_key,
-        args.openrouter_site_url,
-        args.openrouter_app_name,
+        resolve_openrouter_site_url(args.openrouter_site_url),
+        resolve_openrouter_app_name(args.openrouter_app_name),
     )
     artifact = build_artifact(brief, request_payload, api_response, provider, endpoint)
     if args.out:

--- a/tests/test_research_writing_delegate.py
+++ b/tests/test_research_writing_delegate.py
@@ -103,6 +103,78 @@ class ResearchWritingDelegateTests(unittest.TestCase):
         self.assertEqual(environ["OPENROUTER_API_KEY"], "already-set")
         self.assertEqual(environ["RESEARCH_WRITING_DELEGATE_MODEL"], "writer-model")
 
+    def test_env_file_model_is_loaded_before_dry_run_payload(self) -> None:
+        brief = {"task": {"type": "rewrite", "target": "paragraph", "goal": "tighten"}}
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            brief_path = tmp_path / "brief.json"
+            env_path = tmp_path / ".env"
+            brief_path.write_text(json.dumps(brief), encoding="utf-8")
+            env_path.write_text(
+                "RESEARCH_WRITING_DELEGATE_MODEL=moonshotai/kimi-k2.6\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--env-file",
+                    str(env_path),
+                    "--brief",
+                    str(brief_path),
+                    "--dry-run",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={},
+            )
+
+        self.assertEqual(json.loads(result.stdout)["model"], "moonshotai/kimi-k2.6")
+
+    def test_cli_model_overrides_env_file_model(self) -> None:
+        brief = {"task": {"type": "rewrite", "target": "paragraph", "goal": "tighten"}}
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            brief_path = tmp_path / "brief.json"
+            env_path = tmp_path / ".env"
+            brief_path.write_text(json.dumps(brief), encoding="utf-8")
+            env_path.write_text(
+                "RESEARCH_WRITING_DELEGATE_MODEL=moonshotai/kimi-k2.6\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--env-file",
+                    str(env_path),
+                    "--brief",
+                    str(brief_path),
+                    "--model",
+                    "openai/gpt-test",
+                    "--dry-run",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={},
+            )
+
+        self.assertEqual(json.loads(result.stdout)["model"], "openai/gpt-test")
+
+    def test_skill_local_env_file_is_auto_discovered(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            env_path = Path(tmp) / ".env"
+            env_path.write_text("RESEARCH_WRITING_DELEGATE_MODEL=moonshotai/kimi-k2.6\n", encoding="utf-8")
+            original = module.DEFAULT_ENV_FILE_PATH
+            try:
+                module.DEFAULT_ENV_FILE_PATH = env_path
+                self.assertEqual(module.resolve_env_file(None), env_path)
+            finally:
+                module.DEFAULT_ENV_FILE_PATH = original
+
     def test_invalid_brief_fails_before_dry_run(self) -> None:
         brief = {"task": {"type": "rewrite", "target": "paragraph"}}
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

Fixes research-writing-delegate env loading so explicit --env-file values and skill-local .env files are applied before provider/model defaults are resolved.

## Why

The OpenRouter key was present in the local skill .env, but RESEARCH_WRITING_DELEGATE_MODEL from that file was ignored because argparse evaluated environment defaults before load_env_file ran.

## Linked Issue

Closes #34

## Verification

- Local: python -m unittest test_research_writing_delegate.py; explicit env-file dry-run resolved moonshotai/kimi-k2.6; python ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/research-writing-delegate; python scripts/validate_all.py
- Browser: Not applicable; no browser-facing behavior changed.
- Browser evidence: Not applicable.
- CI: Pending GitHub Actions on PR.

## Auto-Merge Eligibility

Not requested. Merge manually after CI passes.

## Blueprint Updates

No blueprint changes.

## Risks / Rollback

Low risk; changes are limited to env/default resolution and tests. Rollback by reverting this PR.

## Follow-ups

Sync the installed local skill after merge so ~/.codex/skills/research-writing-delegate/.env is loaded automatically.
