### PR TITLE
Release research writing delegate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@ __pycache__/
 *.pyc
 .DS_Store
 .venv/
+.env
+.env.*
+!.env.example
+skills/*/.env
+skills/*/.env.*
+!skills/*/.env.example
 .project/todo/
 .project/logs/archive/
 .project/worktrees/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Ora et Labora
 
-Ora et Labora is a repo-first workflow suite for coding agents.
+Ora et Labora is a repo-first workflow suite for coding and research agents.
 
-It is not a bag of prompts. It is a working method for taking nontrivial software changes from rough idea to stable release without relying on agent memory or ad hoc habits.
+It is not a bag of prompts. It is a working method for taking nontrivial software and research work from rough idea to stable release, durable artifact, or verified manuscript state without relying on agent memory or ad hoc habits.
 
 The suite is built around a simple idea:
 
@@ -14,6 +14,7 @@ The suite is built around a simple idea:
 - allow implementation PR auto-merge only after explicit safety gates
 - treat browser evidence and Docker runtime behavior as first-class operational concerns
 - choose a public/private/internal artifact policy before publishing workflow state
+- route research projects through exploratory notebooks, reusable analysis code, paper artifacts, and manuscript operations without bypassing repo discipline
 - integrate normal work and completed epics into `dev`
 - release from `dev` to `main`
 
@@ -32,6 +33,20 @@ Implementation then happens inside the worktree, with verification driven by the
 The branch flow is lane-based and PR-first. Normal work targets `dev`; epic work uses `epic/<slug>` plus an early draft PR to `dev`; urgent hotfixes target `main` first and then reconcile back to `dev`. Parallel epics are allowed, but they must stay rebased on `origin/dev`, and affected epics must rebase immediately when another epic merges or changes shared contracts. Implementation PRs may use agent auto-merge only after branch freshness, verification, CI/review, issue-closure, and state-logging gates are satisfied. Stable promotion happens through grouped `dev` to `main` release PRs, and release or hotfix PRs into `main` require explicit user approval before merge.
 
 Repo creation and bootstrap are visibility-aware. Private and internal repos can version durable `.project/` surfaces such as `.project/blueprint/` and concise `.project/logs/`, while keeping local task workspaces under `.project/todo/` local-only. Public repos keep `.project/` local by default and publish only sanitized contributor-facing docs and GitHub templates.
+
+## Research Profile
+
+Research projects use the same artifact model, but their default surfaces are different. Codex should expect `.project/blueprint/` for research frame, scope, claims, assumptions, and durable decisions; `references/` for external/source material; `papers/` for manuscript sources and nearby compiled outputs; `notebooks/` for exploratory marimo artifacts; and `src/`, `scripts/`, `tests/`, or `data/` when analysis infrastructure becomes reusable.
+
+The research workflow has three lanes:
+
+- exploration: use `marimo-pair` for live human-researcher interaction, diagnostics, exploratory analysis, visualization, and figure prototyping
+- implementation: promote reusable analysis or paper-supporting code into the normal Ora et Labora issue, blueprint, worktree, verification, and PR flow
+- manuscript: use LaTeX/paper skills for manuscript creation, Overleaf sync, PDF checks, citations, `.bbl`, arXiv outputs, and bounded prose-generation workflows
+
+Paper-facing work can route to `latex-document` for LaTeX manuscript setup and local render checks, `overleaf` for Overleaf operations, and `research-writing-delegate` for external-model prose drafting with Codex review and explicit user approval before regeneration or integration.
+
+The profile is intentionally lightweight: it teaches routing and defaults without making every research task run every skill.
 
 ## The Basic Workflow
 
@@ -96,6 +111,7 @@ skills/verify-and-evidence/ modality-based verification and Playwright evidence
 skills/release-train/       grouped dev-to-main release flow
 skills/repo-init/           new repo creation, owner/org, visibility, repo type
 skills/repo-bootstrap/      existing repo templates and workflow bootstrap
+skills/research-writing-delegate/ bounded external-model prose drafting for papers
 scripts/                    install, sync, and validation helpers
 examples/                   concrete end-to-end workflow examples
 .github/workflows/          repo-level validation workflow
@@ -112,6 +128,7 @@ The suite includes:
 - helper scripts for template rendering, issue/PR creation, issue workspace initialization, visibility-aware bootstrap, and Playwright artifact collection
 - a governance helper that can plan or apply default repo settings and a standard issue label set
 - a cleanup helper that removes merged local task state and retires the owning worktree/local branch through a dry-run-first flow
+- a research-writing delegate helper that calls OpenRouter by default, with an OpenAI Responses API fallback, using versioned prompts, validated compact briefs, review artifacts, and structured output schemas
 - a CI gate that rejects malformed implementation or release PR bodies that do not satisfy the suite contract
 
 The operating procedure is intentionally inline in the skill files. Extra files are reserved for templates, scripts, bootstrap assets, tests, and examples.
@@ -137,6 +154,8 @@ The operating procedure is intentionally inline in the skill files. Extra files 
   - creates new local/GitHub repos with the right owner, visibility, repo type, branch model, and initial workflow setup
 - `repo-bootstrap`
   - applies workflow templates and conventions to existing repositories
+- `research-writing-delegate`
+  - delegates bounded academic prose drafts to an external model while preserving Codex review, user approval, and source discipline
 
 ## Install
 
@@ -154,7 +173,8 @@ python ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github
   skills/verify-and-evidence \
   skills/release-train \
   skills/repo-init \
-  skills/repo-bootstrap
+  skills/repo-bootstrap \
+  skills/research-writing-delegate
 ```
 
 Restart Codex after installation so the skill is discovered.

--- a/skills/ora-et-labora/SKILL.md
+++ b/skills/ora-et-labora/SKILL.md
@@ -11,7 +11,7 @@ This is not the main execution skill for most tasks. The focused peer skills own
 
 ## Overview
 
-Ora et Labora is a repo-first workflow for agentic software development. It turns rough work into durable issues, checks feasibility against the project blueprint, executes in a branch worktree, verifies with the right modality, routes PRs through the correct branch lane, and promotes grouped releases from `dev` to `main`.
+Ora et Labora is a repo-first workflow for agentic software and research work. It turns rough work into durable issues, checks feasibility against the project blueprint, executes in a branch worktree when implementation is needed, verifies with the right modality, routes PRs through the correct branch lane, and promotes grouped releases from `dev` to `main`.
 
 Core principle: durable workflow truth must live in the repo, while branch-local task workspace state may stay local to the developer machine.
 
@@ -25,6 +25,7 @@ Use this umbrella skill when:
 - a request could match multiple Ora et Labora skills
 - the agent needs the suite map
 - the agent needs the artifact ownership model
+- the agent needs project-profile routing for software or research work
 - the agent needs to locate templates or helper scripts
 - the task spans issue shaping, worktree flow, verification, and release
 
@@ -42,6 +43,53 @@ Do not use this skill as a substitute for the detailed phase skills. If the task
 | `release-train` | promoting grouped work from `dev` to `main`, release PRs, release checks, and rollback notes |
 | `repo-init` | creating a new local or GitHub repo, choosing owner/org, visibility, repo type, source mode, and initial branch model |
 | `repo-bootstrap` | applying Ora et Labora templates, `.project/blueprint/`, CI/release placeholders, and conventions to an existing repo |
+
+## Project Profiles
+
+Project profiles change default repository structure and likely skill routing. They do not replace the core artifact model, branch lanes, verification rules, or completion standard when the task is nontrivial.
+
+| Profile | Use for | Default expectations |
+| --- | --- | --- |
+| `software` | apps, services, libraries, tools, and infrastructure | use the normal issue, blueprint, worktree, verification, PR, and release lifecycle |
+| `research` | academic or research repos with papers, sources, analysis, notebooks, and manuscript workflows | combine exploratory notebooks, reusable code, source material, and paper artifacts under the same repo-first discipline |
+
+### Research Profile
+
+When a repo is a research project, Codex should expect these surfaces unless a closer `AGENTS.md` or blueprint says otherwise:
+
+- `.project/blueprint/` stores the research frame, scope, claims, assumptions, workflow invariants, and durable decisions.
+- `.project/logs/` stores concise milestones, verification outcomes, and meaningful paper or analysis deltas.
+- `references/` stores external/source material when needed.
+- `papers/` stores authored manuscript sources and compiled outputs that belong beside the source.
+- `notebooks/` stores exploratory marimo notebooks when notebook artifacts are part of the work.
+- `src/`, `scripts/`, `tests/`, and `data/` are used as appropriate for reusable analysis infrastructure.
+
+Research work has three lanes:
+
+| Lane | Use for | Default routing |
+| --- | --- | --- |
+| Exploration | live human-researcher interaction, diagnostics, exploratory analysis, and figure prototyping | use `marimo-pair`; treat marimo as the interactive visualization and reasoning surface |
+| Implementation | reusable analysis code, pipelines, datasets, validators, and paper-supporting infrastructure | use the normal Ora et Labora issue, blueprint, worktree, verification, and PR flow |
+| Manuscript | LaTeX sources, prose, citations, Overleaf sync, PDF checks, and submission outputs | use paper/manuscript skills plus Ora et Labora state and verification discipline when the change is nontrivial |
+
+### Research Skill Routing
+
+| Need | Prefer |
+| --- | --- |
+| live exploratory notebook work with the human in the loop | `marimo-pair` |
+| reusable analysis infrastructure or paper-supporting code | normal Ora et Labora lifecycle skills |
+| LaTeX manuscript creation, template setup, or local PDF/render verification | `latex-document` when available |
+| Overleaf pull, push, sync, compile, `.bbl`, or arXiv output operations | `overleaf` when available; default to project IDs, dry runs, and non-destructive sync |
+| bounded academic prose drafting or revision through an external model | `research-writing-delegate` |
+| claim, framing, or scope decisions that should persist | `blueprint-guard`, `state-logging`, or a decision-tracking skill when available |
+
+Research profile rules:
+
+- Do not treat marimo notebooks as the canonical implementation layer. If exploratory logic becomes relied upon, promote it into reusable code, scripts, tests, logs, or manuscript artifacts.
+- Do not send a whole paper or oversized context packet to an external writing model by default. Use the smallest brief that can produce a useful draft.
+- Do not run a second external writing-generation pass or patch generated prose into the manuscript without first showing Codex's review and proposed next step to the user, unless the user explicitly enabled that automation for the task.
+- For Overleaf work, avoid propagating deletes unless explicitly approved, identify ambiguous projects by ID, and never expose session cookies or credentials in commands, logs, issues, or PR bodies.
+- Manuscript-impacting changes should be verified with the relevant LaTeX/PDF/render check when practical; record skipped checks and residual risk.
 
 ## End-To-End Lifecycle
 
@@ -277,6 +325,8 @@ Prefer scripts for deterministic file layout and template rendering.
 - "I will auto-merge the release PR into `main` because checks are green."
 - "I will publish `.project/` in a public repo because it is only process state."
 - "I will claim frontend verification without browser evidence."
+- "I will leave exploratory notebook logic as the only source of truth for a reusable research result."
+- "I will send an oversized paper dump to an external writing model or regenerate prose without the user's approval."
 - "I will paste complex markdown directly into `gh issue create`."
 - "I will use parallel Docker stacks without isolated ports and project names."
 

--- a/skills/research-writing-delegate/.env.example
+++ b/skills/research-writing-delegate/.env.example
@@ -1,0 +1,16 @@
+# Copy to a local untracked .env when needed. Do not commit real secrets.
+OPENROUTER_API_KEY=
+
+# Default provider/model.
+RESEARCH_WRITING_DELEGATE_PROVIDER=openrouter
+RESEARCH_WRITING_DELEGATE_MODEL=openai/gpt-5.2
+
+# Optional OpenRouter app metadata.
+# OPENROUTER_SITE_URL=
+# OPENROUTER_APP_NAME=Ora et Labora Research Writing Delegate
+
+# Optional skill-specific key override.
+# RESEARCH_WRITING_DELEGATE_API_KEY=
+
+# Optional fallback for --provider openai.
+# OPENAI_API_KEY=

--- a/skills/research-writing-delegate/SKILL.md
+++ b/skills/research-writing-delegate/SKILL.md
@@ -30,7 +30,7 @@ Copy `.env.example` to a local untracked `.env` if needed:
 cp skills/research-writing-delegate/.env.example .env
 ```
 
-Keep `.env` local-only. The committed file is only a template. Optional OpenRouter request metadata can be set with `OPENROUTER_SITE_URL` and `OPENROUTER_APP_NAME`.
+Keep `.env` local-only. The committed file is only a template. The helper automatically loads `skills/research-writing-delegate/.env` when present; pass `--env-file <path>` to use a different local file. Optional OpenRouter request metadata can be set with `OPENROUTER_SITE_URL` and `OPENROUTER_APP_NAME`.
 
 ## Prompt And Template Assets
 
@@ -161,7 +161,7 @@ python skills/research-writing-delegate/scripts/call_delegate.py \
   --out .project/todo/<task-id>/delegate-output.json
 ```
 
-Use `--env-file .env` only with an untracked local file.
+Use `--env-file <path>` only with an untracked local file. CLI flags such as `--model` override `.env` values.
 
 ## Common Mistakes
 

--- a/skills/research-writing-delegate/SKILL.md
+++ b/skills/research-writing-delegate/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: research-writing-delegate
+description: Use when drafting, rewriting, or reviewing academic prose for research papers, LaTeX manuscripts, abstracts, introductions, related work, theory sections, or paper revisions with an external model.
+---
+
+# Research Writing Delegate
+
+## Overview
+
+Use an external model as a bounded prose drafter, not as the paper owner. Codex owns context selection, source discipline, critique, user approval, and final integration.
+
+## Core Rules
+
+- Send the smallest brief that can produce a useful draft. Do not send a whole paper by default.
+- Before an external call, disclose the provider/model and summarize the material that will leave the machine if the brief includes unpublished, sensitive, or collaborator-owned text.
+- Save raw delegate output in local task state or `.project/logs/` before editing it.
+- Never patch generated prose into the manuscript without Codex review.
+- Never run a second generation pass without first showing Codex's review and proposed revision brief to the user, unless the user explicitly enabled automation for the task.
+- Do not store API keys in the repo, skill folder, issues, PRs, logs, or chat. Use environment variables, a local untracked `.env`, or a secret manager.
+
+## Credential Setup
+
+OpenRouter is the default provider. Set `OPENROUTER_API_KEY` in the environment, or use `RESEARCH_WRITING_DELEGATE_API_KEY` as a skill-specific override. Use `OPENAI_API_KEY` only when calling the helper with `--provider openai`.
+
+The default OpenRouter model is `openai/gpt-5.2`. Override it with `RESEARCH_WRITING_DELEGATE_MODEL` or `--model`. The helper requires structured-output support from the routed provider so malformed prose drafts fail fast instead of bypassing the JSON contract.
+
+Copy `.env.example` to a local untracked `.env` if needed:
+
+```bash
+cp skills/research-writing-delegate/.env.example .env
+```
+
+Keep `.env` local-only. The committed file is only a template. Optional OpenRouter request metadata can be set with `OPENROUTER_SITE_URL` and `OPENROUTER_APP_NAME`.
+
+## Prompt And Template Assets
+
+Runtime prompt and artifact contracts are versioned with the skill:
+
+- `prompts/delegate_system.md`: system prompt sent to OpenRouter/OpenAI.
+- `templates/brief.schema.json`: initial brief contract.
+- `templates/revision_brief.schema.json`: regeneration brief contract; requires user approval.
+- `templates/minimal_brief.json`: starting point for compact first-pass briefs.
+- `templates/revision_brief.json`: starting point for user-approved regeneration.
+- `templates/review.md`: Codex review artifact before integration or regeneration.
+
+The helper validates initial and revision briefs before dry-run or API calls. This does not replace Codex judgment; it prevents obvious under-specified or unsafe delegation.
+
+## Brief Levels
+
+| Level | Use when | Include |
+| --- | --- | --- |
+| `minimal` | rewriting or drafting one paragraph | task, goal, target length, current/neighboring text, constraints |
+| `grounded` | claims or citations matter | minimal brief plus selected excerpts, citation keys, allowed uses |
+| `structural` | section flow matters | grounded brief plus outline and paper-level claim boundaries |
+
+Default to `minimal`; escalate only when the review task needs more context.
+
+## Input Brief
+
+Use JSON or YAML-shaped content with these fields when available:
+
+```yaml
+task:
+  type: draft_paragraph | rewrite | tighten | bridge | abstract | critique
+  target: paragraph | subsection | introduction | related_work | theory | limits
+  goal: what the passage must accomplish
+  length: desired length or range
+context:
+  before: short preceding excerpt
+  current: optional current draft
+  after: short following excerpt
+  outline: 3-5 bullets max
+claims:
+  may_make: []
+  must_not_make: []
+sources:
+  - citation_key: key
+    excerpt: short excerpt
+    usable_for: specific permitted use
+style:
+  sample: optional short sample
+  constraints: theory-forward, no empirical overclaiming, etc.
+feedback:
+  previous_draft: only after user-approved revision loop
+  requested_changes: only after user-approved revision loop
+```
+
+Initial briefs must not include `feedback`. Use `--brief-kind revision` only after Codex has reviewed the delegate output, shown the review to the user, and the user approved sending feedback back to the model.
+
+## Output Contract
+
+The delegate must return:
+
+- `draft`: candidate prose.
+- `claims_used`: claims the draft relies on.
+- `assumptions`: assumptions introduced by the draft.
+- `citation_needs`: citations needed or weakly supported.
+- `weak_points`: prose, logic, or evidence weaknesses.
+- `revision_notes`: suggestions for the next pass.
+- `risk_flags`: overclaiming, invented citation, missing source, scope drift, or confidentiality concerns.
+
+## Codex Review Rubric
+
+Before integration or regeneration, review the delegate output against:
+
+- argument fit: whether the prose advances the requested local function without changing the paper's scope.
+- claim fit: whether every substantive claim is in `claims.may_make` or already present in the supplied context.
+- source fit: whether source excerpts and citation keys are used only for their stated `usable_for` purpose.
+- citation risk: whether the draft needs support that was not present in the brief.
+- style fit: whether the passage matches nearby manuscript prose instead of generic academic phrasing.
+- overclaiming: whether the draft turns theory, framing, or exploratory evidence into unsupported empirical claims.
+
+Record the decision in `templates/review.md` before showing a regeneration recommendation to the user.
+
+## Workflow
+
+1. Build a compact brief from the repo, paper, blueprint, and source material.
+2. Show the brief summary before the external call when sensitive text is involved.
+3. Call the delegate and save the artifact.
+4. Create a Codex review artifact from `templates/review.md`.
+5. Review the output against the paper's claims, sources, tone, and neighboring text.
+6. Show the review and recommendation: accept with edits, regenerate, manually edit, or discard.
+7. If regenerating, build a `templates/revision_brief.json`-shaped brief with `feedback.user_approved: true` only after the user approves.
+8. Apply only the reviewed and approved text to the manuscript.
+9. Verify manuscript-impacting changes with the relevant LaTeX/PDF/render check when practical.
+
+## Helper Script
+
+Dry-run the request payload without an API key:
+
+```bash
+python skills/research-writing-delegate/scripts/call_delegate.py \
+  --brief .project/todo/<task-id>/delegate-brief.json \
+  --dry-run
+```
+
+Run through OpenRouter and save a local artifact:
+
+```bash
+python skills/research-writing-delegate/scripts/call_delegate.py \
+  --brief .project/todo/<task-id>/delegate-brief.json \
+  --out .project/todo/<task-id>/delegate-output.json
+```
+
+Run a user-approved regeneration pass:
+
+```bash
+python skills/research-writing-delegate/scripts/call_delegate.py \
+  --brief-kind revision \
+  --brief .project/todo/<task-id>/delegate-revision-brief.json \
+  --out .project/todo/<task-id>/delegate-output-v2.json
+```
+
+Use OpenAI's Responses API explicitly when needed:
+
+```bash
+python skills/research-writing-delegate/scripts/call_delegate.py \
+  --provider openai \
+  --model gpt-5.5 \
+  --brief .project/todo/<task-id>/delegate-brief.json \
+  --out .project/todo/<task-id>/delegate-output.json
+```
+
+Use `--env-file .env` only with an untracked local file.
+
+## Common Mistakes
+
+| Mistake | Fix |
+| --- | --- |
+| Sending the whole manuscript | Send the local section, neighboring text, and only source excerpts needed |
+| Treating delegate text as final | Review claims, citations, tone, and fit before integration |
+| Autoregenerating after critique | Show Codex's review and ask before sending feedback |
+| Putting feedback in a first-pass brief | Use `--brief-kind revision` and require `feedback.user_approved: true` |
+| Storing keys in `.project/` or skill files | Use environment variables, local `.env`, or a secret manager |
+| Letting notebook prose become paper truth | Promote relied-upon claims into blueprint, source notes, code, or manuscript artifacts |

--- a/skills/research-writing-delegate/agents/openai.yaml
+++ b/skills/research-writing-delegate/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Research Writing Delegate"
+  short_description: "Delegate bounded academic prose drafts"
+  default_prompt: "Use $research-writing-delegate to prepare a validated compact paper-writing brief, call the external model only after the right disclosure, and create a Codex review artifact before integration or user-approved regeneration."

--- a/skills/research-writing-delegate/prompts/delegate_system.md
+++ b/skills/research-writing-delegate/prompts/delegate_system.md
@@ -1,0 +1,30 @@
+You are a bounded academic prose drafting delegate, not the paper owner.
+
+Codex owns context selection, source discipline, critique, user approval, and final manuscript integration. You produce candidate prose and diagnostics only.
+
+Task modes:
+- `draft_paragraph`: write one local paragraph that advances the stated goal and stays inside the allowed claims.
+- `rewrite`: improve the supplied draft while preserving its claim boundaries.
+- `tighten`: make prose shorter, clearer, and less repetitive without adding new claims.
+- `bridge`: connect two neighboring passages without changing the paper's scope.
+- `abstract`: draft or revise abstract prose using only the stated contribution, method, evidence, and limitation boundaries.
+- `critique`: return diagnostic notes; keep `draft` empty or minimal if prose is not requested.
+- `related_work`, `theory`, `literature_review`: synthesize only the provided source excerpts and citation keys.
+- `limits`: surface uncertainty, scope boundaries, and evidence limits without weakening claims that are explicitly supported.
+
+Source discipline:
+- Use only the claims and source uses permitted in the brief.
+- Do not invent citations, evidence, results, datasets, methods, or paper scope.
+- If a citation is needed but not supported by the brief, add it to `citation_needs` instead of inventing it.
+- Treat `must_not_make` as binding.
+
+Writing discipline:
+- Match the local paper context, not a generic academic style.
+- Prefer precise causal and conceptual language over broad claims.
+- Avoid promotional language, filler transitions, and unsupported novelty claims.
+- If the brief is under-specified, write the safest useful draft and flag the gap.
+
+Output discipline:
+- Return candidate prose, not final manuscript text.
+- Return JSON only.
+- Return the required JSON schema exactly.

--- a/skills/research-writing-delegate/scripts/call_delegate.py
+++ b/skills/research-writing-delegate/scripts/call_delegate.py
@@ -20,6 +20,7 @@ DEFAULT_PROVIDER = "openrouter"
 DEFAULT_OPENROUTER_MODEL = "openai/gpt-5.2"
 DEFAULT_OPENAI_MODEL = "gpt-5.5"
 SKILL_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_ENV_FILE_PATH = SKILL_DIR / ".env"
 DEFAULT_SYSTEM_PROMPT_PATH = SKILL_DIR / "prompts" / "delegate_system.md"
 ALLOWED_TASK_TYPES = {
     "draft_paragraph",
@@ -63,18 +64,21 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--provider",
         choices=["openrouter", "openai"],
-        default=os.environ.get("RESEARCH_WRITING_DELEGATE_PROVIDER", DEFAULT_PROVIDER),
     )
     parser.add_argument("--brief-kind", choices=["initial", "revision"], default="initial")
     parser.add_argument("--brief", required=True, help="Path to brief JSON, or '-' for stdin.")
     parser.add_argument("--out", type=Path, help="Write artifact JSON to this path.")
-    parser.add_argument("--model", default=os.environ.get("RESEARCH_WRITING_DELEGATE_MODEL"))
+    parser.add_argument("--model")
     parser.add_argument("--system-prompt", type=Path, default=DEFAULT_SYSTEM_PROMPT_PATH)
-    parser.add_argument("--env-file", type=Path, help="Optional local untracked .env file.")
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        help="Optional local untracked .env file. Defaults to skill-local .env when present.",
+    )
     parser.add_argument("--max-output-tokens", type=int, default=1800)
     parser.add_argument("--temperature", type=float, default=0.4)
-    parser.add_argument("--openrouter-site-url", default=os.environ.get("OPENROUTER_SITE_URL"))
-    parser.add_argument("--openrouter-app-name", default=os.environ.get("OPENROUTER_APP_NAME"))
+    parser.add_argument("--openrouter-site-url")
+    parser.add_argument("--openrouter-app-name")
     parser.add_argument("--dry-run", action="store_true", help="Print sanitized request payload without calling the API.")
     return parser.parse_args()
 
@@ -92,6 +96,14 @@ def load_env_file(path: Path, environ: dict[str, str] | None = None) -> None:
         value = value.strip().strip('"').strip("'")
         if key and key not in target:
             target[key] = value
+
+
+def resolve_env_file(explicit_env_file: Path | None) -> Path | None:
+    if explicit_env_file is not None:
+        return explicit_env_file
+    if DEFAULT_ENV_FILE_PATH.exists():
+        return DEFAULT_ENV_FILE_PATH
+    return None
 
 
 def load_brief(path_value: str) -> dict[str, Any]:
@@ -225,12 +237,26 @@ def validate_brief(brief: dict[str, Any], brief_kind: str) -> None:
         raise SystemExit("Brief validation failed:\n- " + "\n- ".join(errors))
 
 
+def resolve_provider(provider: str | None) -> str:
+    return (provider or os.environ.get("RESEARCH_WRITING_DELEGATE_PROVIDER", DEFAULT_PROVIDER)).lower()
+
+
 def resolve_model(provider: str, model: str | None) -> str:
+    if model is None:
+        model = os.environ.get("RESEARCH_WRITING_DELEGATE_MODEL")
     if model:
         return model
     if provider == "openrouter":
         return DEFAULT_OPENROUTER_MODEL
     return DEFAULT_OPENAI_MODEL
+
+
+def resolve_openrouter_site_url(value: str | None) -> str | None:
+    return value or os.environ.get("OPENROUTER_SITE_URL")
+
+
+def resolve_openrouter_app_name(value: str | None) -> str | None:
+    return value or os.environ.get("OPENROUTER_APP_NAME")
 
 
 def build_request(
@@ -406,10 +432,11 @@ def build_artifact(
 
 def main() -> int:
     args = parse_args()
-    if args.env_file:
-        load_env_file(args.env_file)
+    env_file = resolve_env_file(args.env_file)
+    if env_file is not None:
+        load_env_file(env_file)
 
-    provider = args.provider.lower()
+    provider = resolve_provider(args.provider)
     brief = load_brief(args.brief)
     validate_brief(brief, args.brief_kind)
     model = resolve_model(provider, args.model)
@@ -433,8 +460,8 @@ def main() -> int:
         provider,
         endpoint,
         api_key,
-        args.openrouter_site_url,
-        args.openrouter_app_name,
+        resolve_openrouter_site_url(args.openrouter_site_url),
+        resolve_openrouter_app_name(args.openrouter_app_name),
     )
     artifact = build_artifact(brief, request_payload, api_response, provider, endpoint)
     if args.out:

--- a/skills/research-writing-delegate/scripts/call_delegate.py
+++ b/skills/research-writing-delegate/scripts/call_delegate.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Call an external model for bounded academic prose drafting."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+OPENROUTER_CHAT_URL = "https://openrouter.ai/api/v1/chat/completions"
+OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses"
+DEFAULT_PROVIDER = "openrouter"
+DEFAULT_OPENROUTER_MODEL = "openai/gpt-5.2"
+DEFAULT_OPENAI_MODEL = "gpt-5.5"
+SKILL_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_SYSTEM_PROMPT_PATH = SKILL_DIR / "prompts" / "delegate_system.md"
+ALLOWED_TASK_TYPES = {
+    "draft_paragraph",
+    "rewrite",
+    "tighten",
+    "bridge",
+    "abstract",
+    "critique",
+    "related_work",
+    "theory",
+    "literature_review",
+    "limits",
+}
+
+DELEGATE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": [
+        "draft",
+        "claims_used",
+        "assumptions",
+        "citation_needs",
+        "weak_points",
+        "revision_notes",
+        "risk_flags",
+    ],
+    "properties": {
+        "draft": {"type": "string"},
+        "claims_used": {"type": "array", "items": {"type": "string"}},
+        "assumptions": {"type": "array", "items": {"type": "string"}},
+        "citation_needs": {"type": "array", "items": {"type": "string"}},
+        "weak_points": {"type": "array", "items": {"type": "string"}},
+        "revision_notes": {"type": "array", "items": {"type": "string"}},
+        "risk_flags": {"type": "array", "items": {"type": "string"}},
+    },
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--provider",
+        choices=["openrouter", "openai"],
+        default=os.environ.get("RESEARCH_WRITING_DELEGATE_PROVIDER", DEFAULT_PROVIDER),
+    )
+    parser.add_argument("--brief-kind", choices=["initial", "revision"], default="initial")
+    parser.add_argument("--brief", required=True, help="Path to brief JSON, or '-' for stdin.")
+    parser.add_argument("--out", type=Path, help="Write artifact JSON to this path.")
+    parser.add_argument("--model", default=os.environ.get("RESEARCH_WRITING_DELEGATE_MODEL"))
+    parser.add_argument("--system-prompt", type=Path, default=DEFAULT_SYSTEM_PROMPT_PATH)
+    parser.add_argument("--env-file", type=Path, help="Optional local untracked .env file.")
+    parser.add_argument("--max-output-tokens", type=int, default=1800)
+    parser.add_argument("--temperature", type=float, default=0.4)
+    parser.add_argument("--openrouter-site-url", default=os.environ.get("OPENROUTER_SITE_URL"))
+    parser.add_argument("--openrouter-app-name", default=os.environ.get("OPENROUTER_APP_NAME"))
+    parser.add_argument("--dry-run", action="store_true", help="Print sanitized request payload without calling the API.")
+    return parser.parse_args()
+
+
+def load_env_file(path: Path, environ: dict[str, str] | None = None) -> None:
+    target = os.environ if environ is None else environ
+    if not path.exists():
+        raise SystemExit(f"Env file does not exist: {path}")
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in target:
+            target[key] = value
+
+
+def load_brief(path_value: str) -> dict[str, Any]:
+    if path_value == "-":
+        text = sys.stdin.read()
+    else:
+        text = Path(path_value).read_text(encoding="utf-8")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Brief must be JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise SystemExit("Brief must be a JSON object.")
+    return data
+
+
+def load_system_prompt(path: Path) -> str:
+    if not path.exists():
+        raise SystemExit(f"System prompt file does not exist: {path}")
+    prompt = path.read_text(encoding="utf-8").strip()
+    if not prompt:
+        raise SystemExit(f"System prompt file is empty: {path}")
+    return prompt
+
+
+def _is_non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _validate_string_list(value: Any, path: str, errors: list[str], *, allow_empty: bool = True) -> None:
+    if not isinstance(value, list):
+        errors.append(f"{path} must be an array of strings.")
+        return
+    if not allow_empty and not value:
+        errors.append(f"{path} must contain at least one string.")
+        return
+    for index, item in enumerate(value):
+        if not _is_non_empty_string(item):
+            errors.append(f"{path}[{index}] must be a non-empty string.")
+
+
+def _validate_optional_text_fields(
+    data: dict[str, Any],
+    fields: tuple[str, ...],
+    prefix: str,
+    errors: list[str],
+) -> None:
+    for field in fields:
+        if field in data and not isinstance(data[field], str):
+            errors.append(f"{prefix}.{field} must be a string.")
+
+
+def validate_brief(brief: dict[str, Any], brief_kind: str) -> None:
+    errors: list[str] = []
+
+    task = brief.get("task")
+    if not isinstance(task, dict):
+        errors.append("task must be an object.")
+    else:
+        task_type = task.get("type")
+        if not _is_non_empty_string(task_type):
+            errors.append("task.type must be a non-empty string.")
+        elif task_type not in ALLOWED_TASK_TYPES:
+            errors.append(f"task.type must be one of: {', '.join(sorted(ALLOWED_TASK_TYPES))}.")
+        for field in ("target", "goal"):
+            if not _is_non_empty_string(task.get(field)):
+                errors.append(f"task.{field} must be a non-empty string.")
+        if "length" in task and not isinstance(task["length"], str):
+            errors.append("task.length must be a string when present.")
+
+    context = brief.get("context")
+    if context is not None:
+        if not isinstance(context, dict):
+            errors.append("context must be an object when present.")
+        else:
+            _validate_optional_text_fields(context, ("before", "current", "after"), "context", errors)
+            if "outline" in context:
+                _validate_string_list(context["outline"], "context.outline", errors)
+
+    claims = brief.get("claims")
+    if claims is not None:
+        if not isinstance(claims, dict):
+            errors.append("claims must be an object when present.")
+        else:
+            for field in ("may_make", "must_not_make"):
+                if field in claims:
+                    _validate_string_list(claims[field], f"claims.{field}", errors)
+
+    sources = brief.get("sources")
+    if sources is not None:
+        if not isinstance(sources, list):
+            errors.append("sources must be an array when present.")
+        else:
+            for index, source in enumerate(sources):
+                if not isinstance(source, dict):
+                    errors.append(f"sources[{index}] must be an object.")
+                    continue
+                for field in ("citation_key", "excerpt", "usable_for"):
+                    if not _is_non_empty_string(source.get(field)):
+                        errors.append(f"sources[{index}].{field} must be a non-empty string.")
+
+    style = brief.get("style")
+    if style is not None and not isinstance(style, dict):
+        errors.append("style must be an object when present.")
+
+    feedback = brief.get("feedback")
+    if brief_kind == "initial":
+        if feedback is not None:
+            errors.append("feedback is only valid with --brief-kind revision.")
+    else:
+        if not isinstance(feedback, dict):
+            errors.append("feedback must be an object for revision briefs.")
+        else:
+            if not _is_non_empty_string(feedback.get("previous_draft")):
+                errors.append("feedback.previous_draft must be a non-empty string.")
+            codex_review = feedback.get("codex_review")
+            if not isinstance(codex_review, dict):
+                errors.append("feedback.codex_review must be an object.")
+            elif not _is_non_empty_string(codex_review.get("recommendation")):
+                errors.append("feedback.codex_review.recommendation must be a non-empty string.")
+            _validate_string_list(
+                feedback.get("requested_changes"),
+                "feedback.requested_changes",
+                errors,
+                allow_empty=False,
+            )
+            if feedback.get("user_approved") is not True:
+                errors.append("feedback.user_approved must be true before regeneration.")
+
+    if errors:
+        raise SystemExit("Brief validation failed:\n- " + "\n- ".join(errors))
+
+
+def resolve_model(provider: str, model: str | None) -> str:
+    if model:
+        return model
+    if provider == "openrouter":
+        return DEFAULT_OPENROUTER_MODEL
+    return DEFAULT_OPENAI_MODEL
+
+
+def build_request(
+    brief: dict[str, Any],
+    provider: str,
+    model: str,
+    system_prompt: str,
+    max_output_tokens: int,
+    temperature: float,
+) -> dict[str, Any]:
+    user_content = "Draft from this writing brief. Return JSON only.\n\n" + json.dumps(
+        brief,
+        ensure_ascii=False,
+        indent=2,
+    )
+    if provider == "openrouter":
+        return {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_content},
+            ],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "research_writing_delegate_output",
+                    "strict": True,
+                    "schema": DELEGATE_SCHEMA,
+                },
+            },
+            "provider": {"require_parameters": True},
+            "max_tokens": max_output_tokens,
+            "temperature": temperature,
+        }
+
+    return {
+        "model": model,
+        "input": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_content},
+        ],
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "research_writing_delegate_output",
+                "strict": True,
+                "schema": DELEGATE_SCHEMA,
+            }
+        },
+        "max_output_tokens": max_output_tokens,
+        "temperature": temperature,
+    }
+
+
+def endpoint_for_provider(provider: str) -> str:
+    if provider == "openrouter":
+        return OPENROUTER_CHAT_URL
+    return OPENAI_RESPONSES_URL
+
+
+def auth_hint(provider: str) -> str:
+    if provider == "openrouter":
+        return "redacted; sourced from RESEARCH_WRITING_DELEGATE_API_KEY or OPENROUTER_API_KEY"
+    return "redacted; sourced from RESEARCH_WRITING_DELEGATE_API_KEY or OPENAI_API_KEY"
+
+
+def api_key_for_provider(provider: str) -> str | None:
+    override = os.environ.get("RESEARCH_WRITING_DELEGATE_API_KEY")
+    if override:
+        return override
+    if provider == "openrouter":
+        return os.environ.get("OPENROUTER_API_KEY")
+    return os.environ.get("OPENAI_API_KEY")
+
+
+def redact_request(request_payload: dict[str, Any], provider: str, endpoint: str) -> dict[str, Any]:
+    return {
+        "provider": provider,
+        "model": request_payload["model"],
+        "endpoint": endpoint,
+        "request": request_payload,
+        "auth": auth_hint(provider),
+    }
+
+
+def extract_output_text(api_response: dict[str, Any], provider: str) -> str:
+    if provider == "openrouter":
+        choices = api_response.get("choices", [])
+        if not choices:
+            raise SystemExit("Could not find choices in OpenRouter response.")
+        message = choices[0].get("message", {})
+        if message.get("refusal"):
+            raise SystemExit(f"Model refusal: {message.get('refusal')}")
+        content = message.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = [item.get("text", "") for item in content if item.get("type") == "text"]
+            if parts:
+                return "\n".join(parts)
+        raise SystemExit("Could not find message content in OpenRouter response.")
+
+    if isinstance(api_response.get("output_text"), str):
+        return api_response["output_text"]
+
+    parts: list[str] = []
+    for output in api_response.get("output", []):
+        for item in output.get("content", []):
+            if item.get("type") in {"output_text", "text"} and isinstance(item.get("text"), str):
+                parts.append(item["text"])
+            if item.get("type") == "refusal":
+                raise SystemExit(f"Model refusal: {item.get('refusal')}")
+    if not parts:
+        raise SystemExit("Could not find output text in API response.")
+    return "\n".join(parts)
+
+
+def call_api(
+    request_payload: dict[str, Any],
+    provider: str,
+    endpoint: str,
+    api_key: str,
+    openrouter_site_url: str | None = None,
+    openrouter_app_name: str | None = None,
+) -> dict[str, Any]:
+    body = json.dumps(request_payload).encode("utf-8")
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    if provider == "openrouter":
+        if openrouter_site_url:
+            headers["HTTP-Referer"] = openrouter_site_url
+        if openrouter_app_name:
+            headers["X-OpenRouter-Title"] = openrouter_app_name
+    request = urllib.request.Request(
+        endpoint,
+        data=body,
+        method="POST",
+        headers=headers,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"{provider} API error {exc.code}: {detail}") from exc
+
+
+def build_artifact(
+    brief: dict[str, Any],
+    request_payload: dict[str, Any],
+    api_response: dict[str, Any],
+    provider: str,
+    endpoint: str,
+) -> dict[str, Any]:
+    output_text = extract_output_text(api_response, provider)
+    try:
+        parsed_output = json.loads(output_text)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Delegate response was not valid JSON: {exc}\n{output_text}") from exc
+    return {
+        "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "provider": provider,
+        "endpoint": endpoint,
+        "model": request_payload["model"],
+        "brief": brief,
+        "delegate_output": parsed_output,
+        "api_response_id": api_response.get("id"),
+        "usage": api_response.get("usage"),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    if args.env_file:
+        load_env_file(args.env_file)
+
+    provider = args.provider.lower()
+    brief = load_brief(args.brief)
+    validate_brief(brief, args.brief_kind)
+    model = resolve_model(provider, args.model)
+    endpoint = endpoint_for_provider(provider)
+    system_prompt = load_system_prompt(args.system_prompt)
+    request_payload = build_request(brief, provider, model, system_prompt, args.max_output_tokens, args.temperature)
+
+    if args.dry_run:
+        print(json.dumps(redact_request(request_payload, provider, endpoint), indent=2, ensure_ascii=False))
+        return 0
+
+    api_key = api_key_for_provider(provider)
+    if not api_key:
+        raise SystemExit(
+            f"Missing API key for {provider}. {auth_hint(provider)}. "
+            "Set it in the environment, or pass --env-file .env for a local untracked file."
+        )
+
+    api_response = call_api(
+        request_payload,
+        provider,
+        endpoint,
+        api_key,
+        args.openrouter_site_url,
+        args.openrouter_app_name,
+    )
+    artifact = build_artifact(brief, request_payload, api_response, provider, endpoint)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(artifact, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    else:
+        print(json.dumps(artifact, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/research-writing-delegate/templates/brief.schema.json
+++ b/skills/research-writing-delegate/templates/brief.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Research Writing Delegate Brief",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["task"],
+  "not": {
+    "required": ["feedback"]
+  },
+  "properties": {
+    "task": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type", "target", "goal"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "draft_paragraph",
+            "rewrite",
+            "tighten",
+            "bridge",
+            "abstract",
+            "critique",
+            "related_work",
+            "theory",
+            "literature_review",
+            "limits"
+          ]
+        },
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "goal": {
+          "type": "string",
+          "minLength": 1
+        },
+        "length": {
+          "type": "string"
+        }
+      }
+    },
+    "context": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "before": {
+          "type": "string"
+        },
+        "current": {
+          "type": "string"
+        },
+        "after": {
+          "type": "string"
+        },
+        "outline": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "claims": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "may_make": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "must_not_make": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["citation_key", "excerpt", "usable_for"],
+        "properties": {
+          "citation_key": {
+            "type": "string",
+            "minLength": 1
+          },
+          "excerpt": {
+            "type": "string",
+            "minLength": 1
+          },
+          "usable_for": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "style": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/skills/research-writing-delegate/templates/minimal_brief.json
+++ b/skills/research-writing-delegate/templates/minimal_brief.json
@@ -1,0 +1,23 @@
+{
+  "task": {
+    "type": "rewrite",
+    "target": "paragraph",
+    "goal": "Tighten the argument while preserving the current claim boundary.",
+    "length": "120-180 words"
+  },
+  "context": {
+    "before": "",
+    "current": "",
+    "after": "",
+    "outline": []
+  },
+  "claims": {
+    "may_make": [],
+    "must_not_make": []
+  },
+  "sources": [],
+  "style": {
+    "sample": "",
+    "constraints": []
+  }
+}

--- a/skills/research-writing-delegate/templates/review.md
+++ b/skills/research-writing-delegate/templates/review.md
@@ -1,0 +1,52 @@
+# Research Writing Delegate Review
+
+## Delegate Artifact
+
+- Brief:
+- Output:
+- Provider/model:
+
+## Recommendation
+
+Choose one: `accept_with_edits`, `regenerate`, `manual_edit`, `discard`.
+
+Decision:
+
+## Claim Fit
+
+- Claims used correctly:
+- Unsupported or drifted claims:
+- Forbidden claims avoided:
+
+## Source Fit
+
+- Source excerpts used correctly:
+- Missing source support:
+- Citation Risk:
+
+## Paper Fit
+
+- Argument fit:
+- Neighboring text fit:
+- Style fit:
+
+## Risk Flags
+
+- Overclaiming:
+- Invented citation/evidence:
+- Scope drift:
+- Confidentiality concern:
+
+## Proposed Revision Brief
+
+Only fill this section if the recommendation is `regenerate`.
+
+- Previous draft:
+- Codex critique:
+- Requested changes:
+
+## User Approval
+
+Regeneration approved: `yes` / `no`
+
+Do not send feedback to the external model unless the user has approved regeneration.

--- a/skills/research-writing-delegate/templates/revision_brief.json
+++ b/skills/research-writing-delegate/templates/revision_brief.json
@@ -1,0 +1,36 @@
+{
+  "task": {
+    "type": "rewrite",
+    "target": "paragraph",
+    "goal": "Revise the previous draft according to the approved feedback.",
+    "length": "120-180 words"
+  },
+  "context": {
+    "before": "",
+    "current": "",
+    "after": "",
+    "outline": []
+  },
+  "claims": {
+    "may_make": [],
+    "must_not_make": []
+  },
+  "sources": [],
+  "style": {
+    "sample": "",
+    "constraints": []
+  },
+  "feedback": {
+    "previous_draft": "Previous delegate draft goes here.",
+    "codex_review": {
+      "recommendation": "regenerate",
+      "claim_fit": [],
+      "citation_risk": [],
+      "style_fit": []
+    },
+    "requested_changes": [
+      "Apply only the user-approved changes captured from Codex review."
+    ],
+    "user_approved": true
+  }
+}

--- a/skills/research-writing-delegate/templates/revision_brief.schema.json
+++ b/skills/research-writing-delegate/templates/revision_brief.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Research Writing Delegate Revision Brief",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["task", "feedback"],
+  "properties": {
+    "task": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type", "target", "goal"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "draft_paragraph",
+            "rewrite",
+            "tighten",
+            "bridge",
+            "abstract",
+            "critique",
+            "related_work",
+            "theory",
+            "literature_review",
+            "limits"
+          ]
+        },
+        "target": {
+          "type": "string",
+          "minLength": 1
+        },
+        "goal": {
+          "type": "string",
+          "minLength": 1
+        },
+        "length": {
+          "type": "string"
+        }
+      }
+    },
+    "context": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "claims": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "style": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "feedback": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "previous_draft",
+        "codex_review",
+        "requested_changes",
+        "user_approved"
+      ],
+      "properties": {
+        "previous_draft": {
+          "type": "string",
+          "minLength": 1
+        },
+        "codex_review": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["recommendation"],
+          "properties": {
+            "recommendation": {
+              "type": "string",
+              "enum": ["accept_with_edits", "regenerate", "manual_edit", "discard"]
+            },
+            "claim_fit": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "citation_risk": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style_fit": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "requested_changes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "user_approved": {
+          "const": true
+        }
+      }
+    }
+  }
+}

--- a/skills/worktree-flow/SKILL.md
+++ b/skills/worktree-flow/SKILL.md
@@ -187,7 +187,7 @@ Use `gh pr merge --auto --merge` when required checks are still pending and GitH
 
 If GitHub auto-merge is unavailable, blocked by settings, or rejected by branch protection, do not force the merge. Record the blocker and leave the PR open.
 
-Release PRs and hotfix PRs into `main` require explicit user approval before merge, even when checks are green. Do not enable auto-merge for release or hotfix PRs unless the user explicitly says to enable auto-merge for that specific PR. After a hotfix merges to `main`, reconciling the fix into `dev` is mandatory.
+For release PRs into `main` and hotfix PRs into `main`, explicit user approval is required before merge, even when checks are green. Do not enable auto-merge for release or hotfix PRs unless the user explicitly says to enable auto-merge for that specific PR. After a hotfix merges to `main`, reconciling the fix into `dev` is mandatory.
 
 ## Docker Runtime Model
 

--- a/tests/test_research_writing_delegate.py
+++ b/tests/test_research_writing_delegate.py
@@ -103,6 +103,78 @@ class ResearchWritingDelegateTests(unittest.TestCase):
         self.assertEqual(environ["OPENROUTER_API_KEY"], "already-set")
         self.assertEqual(environ["RESEARCH_WRITING_DELEGATE_MODEL"], "writer-model")
 
+    def test_env_file_model_is_loaded_before_dry_run_payload(self) -> None:
+        brief = {"task": {"type": "rewrite", "target": "paragraph", "goal": "tighten"}}
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            brief_path = tmp_path / "brief.json"
+            env_path = tmp_path / ".env"
+            brief_path.write_text(json.dumps(brief), encoding="utf-8")
+            env_path.write_text(
+                "RESEARCH_WRITING_DELEGATE_MODEL=moonshotai/kimi-k2.6\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--env-file",
+                    str(env_path),
+                    "--brief",
+                    str(brief_path),
+                    "--dry-run",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={},
+            )
+
+        self.assertEqual(json.loads(result.stdout)["model"], "moonshotai/kimi-k2.6")
+
+    def test_cli_model_overrides_env_file_model(self) -> None:
+        brief = {"task": {"type": "rewrite", "target": "paragraph", "goal": "tighten"}}
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            brief_path = tmp_path / "brief.json"
+            env_path = tmp_path / ".env"
+            brief_path.write_text(json.dumps(brief), encoding="utf-8")
+            env_path.write_text(
+                "RESEARCH_WRITING_DELEGATE_MODEL=moonshotai/kimi-k2.6\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--env-file",
+                    str(env_path),
+                    "--brief",
+                    str(brief_path),
+                    "--model",
+                    "openai/gpt-test",
+                    "--dry-run",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={},
+            )
+
+        self.assertEqual(json.loads(result.stdout)["model"], "openai/gpt-test")
+
+    def test_skill_local_env_file_is_auto_discovered(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            env_path = Path(tmp) / ".env"
+            env_path.write_text("RESEARCH_WRITING_DELEGATE_MODEL=moonshotai/kimi-k2.6\n", encoding="utf-8")
+            original = module.DEFAULT_ENV_FILE_PATH
+            try:
+                module.DEFAULT_ENV_FILE_PATH = env_path
+                self.assertEqual(module.resolve_env_file(None), env_path)
+            finally:
+                module.DEFAULT_ENV_FILE_PATH = original
+
     def test_invalid_brief_fails_before_dry_run(self) -> None:
         brief = {"task": {"type": "rewrite", "target": "paragraph"}}
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_research_writing_delegate.py
+++ b/tests/test_research_writing_delegate.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "skills" / "research-writing-delegate" / "scripts" / "call_delegate.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("call_delegate", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class ResearchWritingDelegateTests(unittest.TestCase):
+    def test_dry_run_defaults_to_openrouter_and_uses_structured_output(self) -> None:
+        brief = {
+            "task": {"type": "rewrite", "target": "paragraph", "goal": "tighten the mechanism"},
+            "constraints": ["do not add citations", "do not claim empirical validation"],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            brief_path = Path(tmp) / "brief.json"
+            brief_path.write_text(json.dumps(brief), encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--brief",
+                    str(brief_path),
+                    "--model",
+                    "test-model",
+                    "--dry-run",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={},
+            )
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["provider"], "openrouter")
+        self.assertEqual(payload["model"], "test-model")
+        self.assertEqual(payload["endpoint"], "https://openrouter.ai/api/v1/chat/completions")
+        self.assertEqual(payload["request"]["response_format"]["type"], "json_schema")
+        self.assertEqual(
+            payload["request"]["response_format"]["json_schema"]["name"],
+            "research_writing_delegate_output",
+        )
+        self.assertTrue(payload["request"]["provider"]["require_parameters"])
+        self.assertEqual(payload["request"]["messages"][0]["role"], "system")
+        self.assertIn("Task modes", payload["request"]["messages"][0]["content"])
+        self.assertIn("paper owner", payload["request"]["messages"][0]["content"])
+        self.assertNotIn("Authorization", result.stdout)
+        self.assertNotIn("OPENROUTER_API_KEY=", result.stdout)
+
+    def test_openai_provider_still_uses_responses_api_structured_output(self) -> None:
+        brief = {"task": {"type": "rewrite", "target": "paragraph", "goal": "tighten"}}
+        with tempfile.TemporaryDirectory() as tmp:
+            brief_path = Path(tmp) / "brief.json"
+            brief_path.write_text(json.dumps(brief), encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--provider",
+                    "openai",
+                    "--brief",
+                    str(brief_path),
+                    "--model",
+                    "gpt-test",
+                    "--dry-run",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={},
+            )
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["provider"], "openai")
+        self.assertEqual(payload["endpoint"], "https://api.openai.com/v1/responses")
+        self.assertEqual(payload["request"]["text"]["format"]["type"], "json_schema")
+        self.assertEqual(payload["request"]["text"]["format"]["name"], "research_writing_delegate_output")
+
+    def test_env_file_loader_preserves_existing_environment_values(self) -> None:
+        module = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            env_path = Path(tmp) / ".env"
+            env_path.write_text(
+                "OPENROUTER_API_KEY=from-file\nRESEARCH_WRITING_DELEGATE_MODEL='writer-model'\n",
+                encoding="utf-8",
+            )
+            environ = {"OPENROUTER_API_KEY": "already-set"}
+            module.load_env_file(env_path, environ)
+
+        self.assertEqual(environ["OPENROUTER_API_KEY"], "already-set")
+        self.assertEqual(environ["RESEARCH_WRITING_DELEGATE_MODEL"], "writer-model")
+
+    def test_invalid_brief_fails_before_dry_run(self) -> None:
+        brief = {"task": {"type": "rewrite", "target": "paragraph"}}
+        with tempfile.TemporaryDirectory() as tmp:
+            brief_path = Path(tmp) / "brief.json"
+            brief_path.write_text(json.dumps(brief), encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--brief",
+                    str(brief_path),
+                    "--dry-run",
+                ],
+                capture_output=True,
+                text=True,
+                env={},
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Brief validation failed", result.stderr)
+        self.assertIn("task.goal", result.stderr)
+
+    def test_initial_brief_rejects_feedback_payloads(self) -> None:
+        brief = {
+            "task": {"type": "rewrite", "target": "paragraph", "goal": "tighten"},
+            "feedback": {"requested_changes": ["shorter"], "user_approved": True},
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            brief_path = Path(tmp) / "brief.json"
+            brief_path.write_text(json.dumps(brief), encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--brief",
+                    str(brief_path),
+                    "--dry-run",
+                ],
+                capture_output=True,
+                text=True,
+                env={},
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("feedback is only valid with --brief-kind revision", result.stderr)
+
+    def test_revision_brief_requires_user_approval(self) -> None:
+        brief = {
+            "task": {"type": "rewrite", "target": "paragraph", "goal": "tighten"},
+            "feedback": {
+                "previous_draft": "Draft.",
+                "codex_review": {"recommendation": "regenerate"},
+                "requested_changes": ["remove overclaiming"],
+                "user_approved": False,
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            brief_path = Path(tmp) / "brief.json"
+            brief_path.write_text(json.dumps(brief), encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--brief-kind",
+                    "revision",
+                    "--brief",
+                    str(brief_path),
+                    "--dry-run",
+                ],
+                capture_output=True,
+                text=True,
+                env={},
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("feedback.user_approved must be true", result.stderr)
+
+    def test_review_and_revision_templates_include_required_surfaces(self) -> None:
+        template_dir = REPO_ROOT / "skills" / "research-writing-delegate" / "templates"
+        brief_template = json.loads((template_dir / "minimal_brief.json").read_text(encoding="utf-8"))
+        review_template = (template_dir / "review.md").read_text(encoding="utf-8")
+        revision_schema = json.loads((template_dir / "revision_brief.schema.json").read_text(encoding="utf-8"))
+
+        self.assertIn("may_make", brief_template["claims"])
+        self.assertIn("must_not_make", brief_template["claims"])
+        self.assertIn("sources", brief_template)
+        for expected in [
+            "Recommendation",
+            "Claim Fit",
+            "Source Fit",
+            "Citation Risk",
+            "Style fit",
+            "Overclaiming",
+            "Proposed Revision Brief",
+            "User Approval",
+        ]:
+            self.assertIn(expected, review_template)
+        self.assertIn("feedback", revision_schema["required"])
+        self.assertTrue(revision_schema["properties"]["feedback"]["properties"]["user_approved"]["const"])
+
+    def test_extracts_openrouter_chat_completion_content(self) -> None:
+        module = load_module()
+        response = {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps(
+                            {
+                                "draft": "Draft.",
+                                "claims_used": [],
+                                "assumptions": [],
+                                "citation_needs": [],
+                                "weak_points": [],
+                                "revision_notes": [],
+                                "risk_flags": [],
+                            }
+                        )
+                    }
+                }
+            ]
+        }
+        self.assertIn('"draft": "Draft."', module.extract_output_text(response, "openrouter"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Release Scope

Promote the research-writing delegate release from dev to main. This includes the new OpenRouter-backed delegate skill, research-profile routing, validated prompt/brief/review artifacts, and the follow-up env-loading fix for skill-local .env defaults.

## Included PRs

- #33 Harden research writing delegate workflow
- #35 Load research delegate env before model defaults

## Release Checks

- Regression: Passed on clean origin/dev release worktree at a12beee: python scripts/validate_all.py (44 tests plus skill validation).
- Browser verification: Not applicable; no browser-facing behavior changed.
- CI status: Implementation PR checks passed for #33 and #35. Release PR validation pending after creation.
- Migrations / schema: Not applicable; no persistence, schema, deployment, or runtime migration changes.

## Notes

No secrets are committed. OPENROUTER_API_KEY remains local-only. The committed default model is openai/gpt-5.2, while local users can override with RESEARCH_WRITING_DELEGATE_MODEL, including moonshotai/kimi-k2.6 in an ignored skill-local .env.

## Rollback

If needed, revert the release merge commit on main. No migrations or irreversible data changes are included.
