### PR TITLE
feat: add Linear bridge skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,9 @@ Scope: applies to `personal/ora-et-labora/**`.
 - Epic work goes `dev` -> `epic/<slug>` with an early draft PR to `dev`; child issue PRs target the epic branch, and parallel epics must rebase on `origin/dev` after other epics merge or shared contracts change.
 - Hotfix work goes `main` -> `hotfix/<issue>-<slug>` -> PR to `main`, then must be reconciled back to `dev`.
 - Stable releases promote grouped `dev` work -> `main` through release PRs.
+
+## Linear Bridge
+
+- `linear-bridge` is an adapter skill, not a replacement for Ora et Labora execution phases.
+- Use it when Linear issues/projects need to be connected to GitHub issues, PRs, repo-local state, or `.project/logs` evidence.
+- Keep Linear as planning/backlog/status across projects; keep GitHub issues and PRs as repo-local implementation records; keep `.project/logs` as execution evidence.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The suite is built around a simple idea:
 - treat browser evidence and Docker runtime behavior as first-class operational concerns
 - choose a public/private/internal artifact policy before publishing workflow state
 - route research projects through exploratory notebooks, reusable analysis code, paper artifacts, and manuscript operations without bypassing repo discipline
+- bridge Linear planning/backlog items to GitHub issues, PRs, and repo-local evidence without replacing Ora et Labora execution state
 - integrate normal work and completed epics into `dev`
 - release from `dev` to `main`
 
@@ -31,6 +32,8 @@ The key split is intentional: task-local execution state under `.project/todo/` 
 Implementation then happens inside the worktree, with verification driven by the type of change. Frontend work is not "tested" in the abstract; it is verified in the browser, with Playwright evidence collected into a stable repo-local log path. Docker-backed projects are handled with explicit worktree rules so switching branches does not turn into port collisions and stale containers.
 
 The branch flow is lane-based and PR-first. Normal work targets `dev`; epic work uses `epic/<slug>` plus an early draft PR to `dev`; urgent hotfixes target `main` first and then reconcile back to `dev`. Parallel epics are allowed, but they must stay rebased on `origin/dev`, and affected epics must rebase immediately when another epic merges or changes shared contracts. Implementation PRs may use agent auto-merge only after branch freshness, verification, CI/review, issue-closure, and state-logging gates are satisfied. Stable promotion happens through grouped `dev` to `main` release PRs, and release or hotfix PRs into `main` require explicit user approval before merge.
+
+Linear can sit above this flow as a planning and backlog surface. A Linear issue may later become one GitHub issue, several GitHub issues, or no GitHub issue at all. When work starts from Linear, use the bridge skill to read the Linear context, decide whether repo-local GitHub issue shaping is needed, link both directions, and comment high-signal PR, blocker, decision, verification, and completion updates back to Linear. Keep `.project/logs` as the repo-local execution evidence.
 
 Repo creation and bootstrap are visibility-aware. Private and internal repos can version durable `.project/` surfaces such as `.project/blueprint/` and concise `.project/logs/`, while keeping local task workspaces under `.project/todo/` local-only. Public repos keep `.project/` local by default and publish only sanitized contributor-facing docs and GitHub templates.
 
@@ -112,6 +115,7 @@ skills/release-train/       grouped dev-to-main release flow
 skills/repo-init/           new repo creation, owner/org, visibility, repo type
 skills/repo-bootstrap/      existing repo templates and workflow bootstrap
 skills/research-writing-delegate/ bounded external-model prose drafting for papers
+skills/linear-bridge/       Linear planning to GitHub/Ora execution linkage
 scripts/                    install, sync, and validation helpers
 examples/                   concrete end-to-end workflow examples
 .github/workflows/          repo-level validation workflow
@@ -129,6 +133,7 @@ The suite includes:
 - a governance helper that can plan or apply default repo settings and a standard issue label set
 - a cleanup helper that removes merged local task state and retires the owning worktree/local branch through a dry-run-first flow
 - a research-writing delegate helper that calls OpenRouter by default, with an OpenAI Responses API fallback, using versioned prompts, validated compact briefs, review artifacts, and structured output schemas
+- a Linear bridge skill for linking planning issues/projects to GitHub issues, PRs, decisions, blockers, verification, and completion updates
 - a CI gate that rejects malformed implementation or release PR bodies that do not satisfy the suite contract
 
 The operating procedure is intentionally inline in the skill files. Extra files are reserved for templates, scripts, bootstrap assets, tests, and examples.
@@ -156,6 +161,8 @@ The operating procedure is intentionally inline in the skill files. Extra files 
   - applies workflow templates and conventions to existing repositories
 - `research-writing-delegate`
   - delegates bounded academic prose drafts to an external model while preserving Codex review, user approval, and source discipline
+- `linear-bridge`
+  - connects Linear issues and projects to GitHub issues, PRs, Ora et Labora task state, and repo-local evidence without replacing `.project/logs`
 
 ## Install
 
@@ -174,7 +181,8 @@ python ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github
   skills/release-train \
   skills/repo-init \
   skills/repo-bootstrap \
-  skills/research-writing-delegate
+  skills/research-writing-delegate \
+  skills/linear-bridge
 ```
 
 Restart Codex after installation so the skill is discovered.

--- a/scripts/install_suite.py
+++ b/scripts/install_suite.py
@@ -19,6 +19,7 @@ SKILL_PATHS = [
     "skills/release-train",
     "skills/repo-init",
     "skills/repo-bootstrap",
+    "skills/linear-bridge",
 ]
 
 

--- a/skills/linear-bridge/SKILL.md
+++ b/skills/linear-bridge/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: linear-bridge
+description: Use when Linear issues, projects, or captured planning items need to be connected to GitHub issues, PRs, Ora et Labora execution state, or repo-local evidence.
+---
+
+# linear-bridge
+
+## Overview
+
+Linear is the planning and cross-project backlog layer. GitHub issues and PRs remain the repo-local execution contract. Ora et Labora still owns shaping, blueprint fit, worktrees, verification, PRs, and evidence.
+
+Use this skill to connect those layers without turning Linear into an implementation log or replacing `.project/logs`.
+
+## When To Use
+
+Use this skill when:
+
+- the user asks Codex to work from a Linear issue or Linear project
+- a captured Linear item needs routing into a repo, GitHub issue, or Ora et Labora task
+- an implementation PR should be linked back to Linear
+- a planning decision made in Linear should be reflected in repo-local workflow state
+- Codex needs to comment progress, blockers, verification, or PR links back to Linear
+
+Do not use this skill for:
+
+- raw note capture that belongs in Obsidian
+- ordinary GitHub-only implementation when no Linear object exists
+- replacing `state-logging`; keep repo execution evidence in `.project/logs`
+- broad Linear cleanup or workspace reorganization unless explicitly requested
+
+## Layer Contract
+
+| Layer | Owns |
+| --- | --- |
+| Linear issue | planning item, priority, project backlog position, cross-project visibility |
+| Linear project | outcome/backlog grouping across one area of work |
+| GitHub issue | repo-local implementation contract, acceptance criteria, verification plan |
+| PR | code change, review, CI, merge record |
+| `.project/logs` | concise execution evidence and meaningful deltas |
+| `.project/blueprint` | durable repo knowledge and workflow invariants |
+
+One Linear issue can map to no GitHub issue, one GitHub issue, or several GitHub issues. Create GitHub issues only when repo-local implementation or review needs them.
+
+## Capture And Triage Defaults
+
+For the personal capture flow:
+
+- new iPhone or MacBook captures land in `linear-personal`, team `Cerebro`
+- use project `Capture & Triage`
+- use source labels such as `capture:iphone` or `capture:macbook`
+- use the team's existing backlog-like state for raw captures unless the workspace has a dedicated `Triage` status
+
+Triage should:
+
+- retitle obvious raw captures
+- ask questions as Linear comments when information is missing
+- attach clear items to the right Linear project
+- leave unclear items in the capture project or move them to the team's review/clarification state
+- avoid creating GitHub issues until a repo and implementation boundary are clear
+
+## Work From Linear
+
+When the user asks to execute a Linear item:
+
+1. Read the Linear issue and project.
+2. Identify the target repo from the issue, project, links, comments, or AGENTS routing.
+3. Read the closest repo `AGENTS.md` and blueprint before changing files.
+4. Decide whether a GitHub issue is needed.
+   - If implementation is nontrivial or PR-bound, create or link a GitHub issue.
+   - If the work is tiny, a PR can link directly to the Linear issue instead.
+5. Use Ora et Labora phase skills for shaping, blueprint fit, state, worktree, verification, and PR flow.
+6. Link both directions:
+   - Linear comment or description: `GitHub: owner/repo#123` and PR link when available.
+   - GitHub issue or PR body: `Linear: <issue key or URL>`.
+7. Comment back to Linear only with high-signal updates: GitHub issue, PR, blocker, decision needed, verification result, completion.
+
+## Common Mistakes
+
+- Do not mirror every GitHub issue into Linear. Link selectively.
+- Do not use Linear comments as an implementation diary. Keep command/test evidence in repo logs and PR bodies.
+- Do not move private captured ideas into shared Linear workspaces without user approval.
+- Do not let a scheduled triage job start coding. Triage can classify and ask; execution needs a clear user trigger or an approved queue.

--- a/skills/ora-et-labora/SKILL.md
+++ b/skills/ora-et-labora/SKILL.md
@@ -43,6 +43,7 @@ Do not use this skill as a substitute for the detailed phase skills. If the task
 | `release-train` | promoting grouped work from `dev` to `main`, release PRs, release checks, and rollback notes |
 | `repo-init` | creating a new local or GitHub repo, choosing owner/org, visibility, repo type, source mode, and initial branch model |
 | `repo-bootstrap` | applying Ora et Labora templates, `.project/blueprint/`, CI/release placeholders, and conventions to an existing repo |
+| `linear-bridge` | connecting Linear issues/projects with GitHub issues, PRs, Ora et Labora execution state, and repo-local evidence |
 
 ## Project Profiles
 
@@ -93,6 +94,9 @@ Research profile rules:
 
 ## End-To-End Lifecycle
 
+0. Connect planning source when needed.
+   - Use `linear-bridge` when work starts from Linear or needs Linear updates.
+   - Keep Linear as planning/backlog; GitHub issues and PRs remain repo-local execution records.
 1. Shape the issue.
    - Use `issue-shaping`.
    - Produce a challenge record and issue body.
@@ -133,6 +137,7 @@ Research profile rules:
 - Run a blueprint fit check for every nontrivial issue before implementation starts.
 - Update `.project/blueprint/` only when durable project knowledge changes.
 - Keep logs delta-only. Do not restate information that already lives in GitHub or `CURRENT.md`.
+- When a Linear issue or project is the planning source, use `linear-bridge` to link Linear to the GitHub issue/PR and to comment high-signal decisions, blockers, and completion back to Linear. Do not replace `.project/logs` with Linear comments.
 - The normal lane uses one issue, one owning branch, one worktree, one local resumable task workspace, and one append-only log per nontrivial task. The epic lane and hotfix lane below are explicit overrides to this default. The epic lane replaces the old module-branch wording and must not revive the legacy module lifecycle.
 - Choose verification modalities based on the change type. Do not treat "tests" as a single generic step.
 - For frontend-impacting work, require browser verification locally and prefer CI browser coverage as well.


### PR DESCRIPTION
## Summary
- add a linear-bridge skill for connecting Linear planning items to GitHub/Ora execution
- document Linear as an upstream planning/backlog surface, not a replacement for .project logs
- include the bridge in the suite install paths and AGENTS guidance

## Verification
- python /home/emmepra/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/linear-bridge
- python scripts/validate_all.py